### PR TITLE
[NFC] Ignore the .swiftpm directory to avoid potential commits of project data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ DerivedData/
 .swiftpm/config/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+.swiftpm


### PR DESCRIPTION
This ignores `.swiftpm` directories to avoid accidental check-ins of project data. This has no functional changes to any build or general package structure.