### PR TITLE
Remove Codable, Hashable, and Equatable conditional conformance

### DIFF
--- a/Guides/Lazy.md
+++ b/Guides/Lazy.md
@@ -30,12 +30,6 @@ public struct AsyncLazySequence<Base: Sequence>: AsyncSequence {
 
 extension AsyncLazySequence: Sendable where Base: Sendable { }
 extension AsyncLazySequence.Iterator: Sendable where Base.Iterator: Sendable { }
-
-extension AsyncLazySequence: Codable where Base: Codable { }
-
-extension AsyncLazySequence: Equatable where Base: Equatable { }
-
-extension AsyncLazySequence: Hashable where Base: Hashable { }
 ```
 
 The resulting `AsyncLazySequence` is an `AsyncSequence`, with conditional conformance to `Sendable`, `Codable`, `Equatable`, 

--- a/Sources/AsyncAlgorithms/AsyncLazySequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncLazySequence.swift
@@ -68,11 +68,3 @@ public struct AsyncLazySequence<Base: Sequence>: AsyncSequence {
 
 extension AsyncLazySequence: Sendable where Base: Sendable { }
 extension AsyncLazySequence.Iterator: Sendable where Base.Iterator: Sendable { }
-
-extension AsyncLazySequence: Codable where Base: Codable { }
-
-extension AsyncLazySequence: Equatable where Base: Equatable { }
-
-extension AsyncLazySequence: Hashable where Base: Hashable { }
-
-

--- a/Sources/AsyncAlgorithms/AsyncZip2Sequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncZip2Sequence.swift
@@ -158,9 +158,3 @@ extension AsyncZip2Sequence: AsyncSequence {
     Iterator(base1.makeAsyncIterator(), base2.makeAsyncIterator())
   }
 }
-
-extension AsyncZip2Sequence: Codable where Base1: Codable, Base2: Codable { }
-
-extension AsyncZip2Sequence: Equatable where Base1: Equatable, Base2: Equatable { }
-
-extension AsyncZip2Sequence: Hashable where Base1: Hashable, Base2: Hashable { }

--- a/Sources/AsyncAlgorithms/AsyncZip3Sequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncZip3Sequence.swift
@@ -203,9 +203,3 @@ extension AsyncZip3Sequence: AsyncSequence {
     Iterator(base1.makeAsyncIterator(), base2.makeAsyncIterator(), base3.makeAsyncIterator())
   }
 }
-
-extension AsyncZip3Sequence: Codable where Base1: Codable, Base2: Codable, Base3: Codable { }
-
-extension AsyncZip3Sequence: Equatable where Base1: Equatable, Base2: Equatable, Base3: Equatable { }
-
-extension AsyncZip3Sequence: Hashable where Base1: Hashable, Base2: Hashable, Base3: Hashable { }


### PR DESCRIPTION
Codable, Hashable, and Equatable don't offer much value for AsyncSequences so their conformances are removed for simplicity as a requirement for async sequences.