### PR TITLE
Add a sequence for joining multiple async sequences with separators

### DIFF
--- a/Sources/AsyncAlgorithms/AsyncJoinedSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncJoinedSequence.swift
@@ -1,0 +1,147 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Async Algorithms open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+extension AsyncSequence where Element: AsyncSequence {
+  @inlinable
+  public func joined<Separator: AsyncSequence>(separator: Separator) -> AsyncJoinedSequence<Self, Separator> {
+    return AsyncJoinedSequence(self, separator: separator)
+  }
+}
+
+public struct AsyncJoinedSequence<Base: AsyncSequence, Separator: AsyncSequence>: AsyncSequence where Base.Element: AsyncSequence, Separator.Element == Base.Element.Element {
+  public typealias Element = Base.Element.Element
+  public typealias AsyncIterator = Iterator
+
+  public struct Iterator: AsyncIteratorProtocol {
+    @usableFromInline
+    enum State {
+      @usableFromInline
+      enum SeparatorState {
+        case initial(Separator)
+        case partialAsync(Separator.AsyncIterator, ContiguousArray<Element>)
+        case cached(ContiguousArray<Element>)
+        case partialCached(ContiguousArray<Element>.Iterator, ContiguousArray<Element>)
+
+        @usableFromInline
+        func startSeparator() -> SeparatorState {
+          switch self {
+            case .initial(let separatorSequence):
+              return .partialAsync(separatorSequence.makeAsyncIterator(), [])
+            case .cached(let array):
+              return .partialCached(array.makeIterator(), array)
+            default:
+              fatalError("Invalid separator sequence state")
+          }
+        }
+
+        @usableFromInline
+        func next() async rethrows -> (Element?, SeparatorState) {
+          switch self {
+            case .partialAsync(var separatorIterator, var cache):
+              guard let next = try await separatorIterator.next() else {
+                return (nil, .cached(cache))
+              }
+              cache.append(next)
+              return (next, .partialAsync(separatorIterator, cache))
+            case .partialCached(var cacheIterator, let cache):
+              guard let next = cacheIterator.next() else {
+                return (nil, .cached(cache))
+              }
+              return (next, .partialCached(cacheIterator, cache))
+            default:
+              fatalError("Invalid separator sequence state")
+          }
+        }
+      }
+
+      case initial(Base.AsyncIterator, Separator)
+      case sequence(Base.AsyncIterator, Base.Element.AsyncIterator, SeparatorState)
+      case separator(Base.AsyncIterator, SeparatorState, Base.Element)
+      case terminal
+    }
+
+    @usableFromInline
+    var state: State
+
+    @usableFromInline
+    init(_ iterator: Base.AsyncIterator, separator: Separator) {
+      state = .initial(iterator, separator)
+    }
+
+    @inlinable
+    public mutating func next() async rethrows -> Base.Element.Element? {
+      do {
+        switch state {
+          case .terminal:
+            return nil
+          case .initial(var outerIterator, let separator):
+            guard let innerSequence = try await outerIterator.next() else {
+              state = .terminal
+              return nil
+            }
+            let innerIterator = innerSequence.makeAsyncIterator()
+            state = .sequence(outerIterator, innerIterator, .initial(separator))
+            return try await next()
+          case .sequence(var outerIterator, var innerIterator, let separatorState):
+              if let item = try await innerIterator.next() {
+                state = .sequence(outerIterator, innerIterator, separatorState)
+                return item
+              }
+
+              guard let nextInner = try await outerIterator.next() else {
+                state = .terminal
+                return nil
+              }
+
+              state = .separator(outerIterator, separatorState.startSeparator(), nextInner)
+              return try await next()
+          case .separator(let iterator, let separatorState, let nextBase):
+            let (itemOpt, newSepState) = try await separatorState.next()
+            guard let item = itemOpt else {
+              state = .sequence(iterator, nextBase.makeAsyncIterator(), newSepState)
+              return try await next()
+            }
+            state = .separator(iterator, newSepState, nextBase)
+            return item
+        }
+      } catch {
+        state = .terminal
+        throw error
+      }
+    }
+  }
+
+  @usableFromInline
+  let base: Base
+
+  @usableFromInline
+  let separator: Separator
+
+  @usableFromInline
+  init(_ base: Base, separator: Separator) {
+    self.base = base
+    self.separator = separator
+  }
+
+  @inlinable
+  public func makeAsyncIterator() -> Iterator {
+    return Iterator(base.makeAsyncIterator(), separator: separator)
+  }
+}
+
+extension AsyncJoinedSequence: Sendable
+  where Base: Sendable, Base.Element: Sendable, Base.Element.Element: Sendable, Base.AsyncIterator: Sendable, Separator: Sendable, Separator.AsyncIterator: Sendable, Base.Element.AsyncIterator: Sendable { }
+extension AsyncJoinedSequence.Iterator: Sendable
+  where Base: Sendable, Base.Element: Sendable, Base.Element.Element: Sendable, Base.AsyncIterator: Sendable, Separator: Sendable, Separator.AsyncIterator: Sendable, Base.Element.AsyncIterator: Sendable { }
+extension AsyncJoinedSequence.Iterator.State: Sendable
+  where Base: Sendable, Base.Element: Sendable, Base.Element.Element: Sendable, Base.AsyncIterator: Sendable, Separator: Sendable, Separator.AsyncIterator: Sendable, Base.Element.AsyncIterator: Sendable { }
+extension AsyncJoinedSequence.Iterator.State.SeparatorState: Sendable
+  where Base: Sendable, Base.Element: Sendable, Base.Element.Element: Sendable, Base.AsyncIterator: Sendable, Separator: Sendable, Separator.AsyncIterator: Sendable, Base.Element.AsyncIterator: Sendable { }

--- a/Tests/AsyncAlgorithmsTests/TestJoin.swift
+++ b/Tests/AsyncAlgorithmsTests/TestJoin.swift
@@ -1,0 +1,131 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Async Algorithms open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import AsyncAlgorithms
+
+extension Sequence where Element: Sequence, Element.Element: Equatable & Sendable {
+  func nestedAsync(throwsOn bad: Element.Element) -> AsyncLazySequence<[AsyncThrowingMapSequence<AsyncLazySequence<Element>,Element.Element>]> {
+    let array: [AsyncThrowingMapSequence<AsyncLazySequence<Element>,Element.Element>] = self.map { $0.async }.map {
+      $0.map { try throwOn(bad, $0) }
+    }
+    return array.async
+  }
+}
+
+extension Sequence where Element: Sequence, Element.Element: Sendable {
+  var nestedAsync : AsyncLazySequence<[AsyncLazySequence<Element>]> {
+    return self.map { $0.async }.async
+  }
+}
+
+final class TestJoin: XCTestCase {
+  func test_join() async {
+    let sequences = [[1, 2, 3], [4, 5, 6], [7, 8, 9]].nestedAsync
+    var iterator = sequences.joined(separator: [-1, -2, -3].async).makeAsyncIterator()
+    let expected = [1, 2, 3, -1, -2, -3, 4, 5, 6, -1, -2, -3, 7, 8, 9]
+    var actual = [Int]()
+    while let item = await iterator.next() {
+      actual.append(item)
+    }
+    XCTAssertEqual(expected, actual)
+    let pastEnd = await iterator.next()
+    XCTAssertNil(pastEnd)
+  }
+
+  func test_join_single_sequence() async {
+    let sequences = [[1, 2, 3]].nestedAsync
+    var iterator = sequences.joined(separator: [-1, -2, -3].async).makeAsyncIterator()
+    let expected = [1, 2, 3]
+    var actual = [Int]()
+    while let item = await iterator.next() {
+      actual.append(item)
+    }
+    XCTAssertEqual(expected, actual)
+    let pastEnd = await iterator.next()
+    XCTAssertNil(pastEnd)
+  }
+
+  func test_join_empty() async {
+    let sequences = [AsyncLazySequence<[Int]>]().async
+    var iterator = sequences.joined(separator: [-1, -2, -3].async).makeAsyncIterator()
+    let expected = [Int]()
+    var actual = [Int]()
+    while let item = await iterator.next() {
+      actual.append(item)
+    }
+    XCTAssertEqual(expected, actual)
+    let pastEnd = await iterator.next()
+    XCTAssertNil(pastEnd)
+  }
+
+  func test_throwing() async throws {
+    let sequences = [[1, 2, 3], [4, 5, 6]].nestedAsync(throwsOn: 5)
+    var iterator = sequences.joined(separator: [-1, -2, -3].async).makeAsyncIterator()
+    let expected = [1, 2, 3, -1, -2, -3, 4]
+    var actual = [Int]()
+    do {
+      while let item = try await iterator.next() {
+        actual.append(item)
+      }
+      XCTFail()
+    } catch {
+      XCTAssertEqual(Failure(), error as? Failure)
+    }
+    XCTAssertEqual(expected, actual)
+    let pastEnd = try await iterator.next()
+    XCTAssertNil(pastEnd)
+  }
+
+  func test_throwing_separator() async throws {
+    let sequences = [[1, 2, 3], [4, 5, 6]].nestedAsync
+    let separator = [-1, -2, -3].async.map { try throwOn(-2, $0) }
+    var iterator = sequences.joined(separator: separator).makeAsyncIterator()
+    let expected = [1, 2, 3, -1]
+    var actual = [Int]()
+    do {
+      while let item = try await iterator.next() {
+        actual.append(item)
+      }
+      XCTFail()
+    } catch {
+      XCTAssertEqual(Failure(), error as? Failure)
+    }
+    XCTAssertEqual(expected, actual)
+    let pastEnd = try await iterator.next()
+    XCTAssertNil(pastEnd)
+  }
+
+  func test_cancellation() async {
+    let source : AsyncLazySequence<[AsyncLazySequence<Indefinite<String>>]> = [Indefinite(value: "test").async].async
+    let sequence = source.joined(separator: ["past indefinite"].async)
+    let finished = expectation(description: "finished")
+    let iterated = expectation(description: "iterated")
+    let task = Task {
+      var firstIteration = false
+      for await el in sequence {
+        XCTAssertEqual(el, "test")
+
+        if !firstIteration {
+          firstIteration = true
+          iterated.fulfill()
+        }
+      }
+      finished.fulfill()
+    }
+    // ensure the other task actually starts
+    wait(for: [iterated], timeout: 1.0)
+    // cancellation should ensure the loop finishes
+    // without regards to the remaining underlying sequence
+    task.cancel()
+    wait(for: [finished], timeout: 1.0)
+  }
+}


### PR DESCRIPTION
The async version of the stdlib's https://github.com/apple/swift/blob/main/stdlib/public/core/Join.swift.

Like the stdlib implementation, the separator sequence is incrementally cached instead of enumerating that same sequence repeatedly.