### PR TITLE
Clean up some asserts by making helper overloads

### DIFF
--- a/Tests/AsyncAlgorithmsTests/Asserts.swift
+++ b/Tests/AsyncAlgorithmsTests/Asserts.swift
@@ -1,0 +1,152 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Async Algorithms open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+
+fileprivate enum _XCTAssertion {
+  case equal
+  case equalWithAccuracy
+  case identical
+  case notIdentical
+  case greaterThan
+  case greaterThanOrEqual
+  case lessThan
+  case lessThanOrEqual
+  case notEqual
+  case notEqualWithAccuracy
+  case `nil`
+  case notNil
+  case unwrap
+  case `true`
+  case `false`
+  case fail
+  case throwsError
+  case noThrow
+  
+  var name: String? {
+    switch(self) {
+    case .equal: return "XCTAssertEqual"
+    case .equalWithAccuracy: return "XCTAssertEqual"
+    case .identical: return "XCTAssertIdentical"
+    case .notIdentical: return "XCTAssertNotIdentical"
+    case .greaterThan: return "XCTAssertGreaterThan"
+    case .greaterThanOrEqual: return "XCTAssertGreaterThanOrEqual"
+    case .lessThan: return "XCTAssertLessThan"
+    case .lessThanOrEqual: return "XCTAssertLessThanOrEqual"
+    case .notEqual: return "XCTAssertNotEqual"
+    case .notEqualWithAccuracy: return "XCTAssertNotEqual"
+    case .`nil`: return "XCTAssertNil"
+    case .notNil: return "XCTAssertNotNil"
+    case .unwrap: return "XCTUnwrap"
+    case .`true`: return "XCTAssertTrue"
+    case .`false`: return "XCTAssertFalse"
+    case .throwsError: return "XCTAssertThrowsError"
+    case .noThrow: return "XCTAssertNoThrow"
+    case .fail: return nil
+    }
+  }
+}
+
+fileprivate enum _XCTAssertionResult {
+  case success
+  case expectedFailure(String?)
+  case unexpectedFailure(Swift.Error)
+  
+  var isExpected: Bool {
+    switch self {
+    case .unexpectedFailure(_): return false
+    default: return true
+    }
+  }
+  
+  func failureDescription(_ assertion: _XCTAssertion) -> String {
+    let explanation: String
+    switch self {
+    case .success: explanation = "passed"
+    case .expectedFailure(let details?): explanation = "failed: \(details)"
+    case .expectedFailure(_): explanation = "failed"
+    case .unexpectedFailure(let error): explanation = "threw error \"\(error)\""
+    }
+    
+    if let name = assertion.name {
+      return "\(name) \(explanation)"
+    } else {
+      return explanation
+    }
+  }
+}
+
+private func _XCTEvaluateAssertion(_ assertion: _XCTAssertion, message: () -> String, file: StaticString, line: UInt, expression: () throws -> _XCTAssertionResult) {
+  let result: _XCTAssertionResult
+  do {
+    result = try expression()
+  } catch {
+    result = .unexpectedFailure(error)
+  }
+  
+  switch result {
+  case .success:
+    return
+  default:
+    XCTFail("\(result.failureDescription(assertion)) - \(message())", file: file, line: line)
+  }
+}
+
+fileprivate func _XCTAssertEqual<T>(_ expression1: () throws -> T, _ expression2: () throws -> T, _ equal: (T, T) -> Bool, _ message: () -> String, file: StaticString = #filePath, line: UInt = #line) {
+  _XCTEvaluateAssertion(.equal, message: message, file: file, line: line) {
+    let (value1, value2) = (try expression1(), try expression2())
+    if equal(value1, value2) {
+      return .success
+    } else {
+      return .expectedFailure("(\"\(value1)\") is not equal to (\"\(value2)\")")
+    }
+  }
+}
+
+public func XCTAssertEqual<A: Equatable, B: Equatable>(_ expression1: @autoclosure () throws -> (A, B), _ expression2: @autoclosure () throws -> (A, B), _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) {
+  _XCTAssertEqual(expression1, expression2, { $0 == $1 }, message, file: file, line: line)
+}
+
+fileprivate func ==<A: Equatable, B: Equatable>(_ lhs: [(A, B)], _ rhs: [(A, B)]) -> Bool {
+  guard lhs.count == rhs.count else {
+    return false
+  }
+  for (lhsElement, rhsElement) in zip(lhs, rhs) {
+    if lhsElement != rhsElement {
+      return false
+    }
+  }
+  return true
+}
+
+public func XCTAssertEqual<A: Equatable, B: Equatable>(_ expression1: @autoclosure () throws -> [(A, B)], _ expression2: @autoclosure () throws -> [(A, B)], _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) {
+  _XCTAssertEqual(expression1, expression2, { $0 == $1 }, message, file: file, line: line)
+}
+
+public func XCTAssertEqual<A: Equatable, B: Equatable, C: Equatable>(_ expression1: @autoclosure () throws -> (A, B, C), _ expression2: @autoclosure () throws -> (A, B, C), _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) {
+  _XCTAssertEqual(expression1, expression2, { $0 == $1 }, message, file: file, line: line)
+}
+
+fileprivate func ==<A: Equatable, B: Equatable, C: Equatable>(_ lhs: [(A, B, C)], _ rhs: [(A, B, C)]) -> Bool {
+  guard lhs.count == rhs.count else {
+    return false
+  }
+  for (lhsElement, rhsElement) in zip(lhs, rhs) {
+    if lhsElement != rhsElement {
+      return false
+    }
+  }
+  return true
+}
+
+public func XCTAssertEqual<A: Equatable, B: Equatable, C: Equatable>(_ expression1: @autoclosure () throws -> [(A, B, C)], _ expression2: @autoclosure () throws -> [(A, B, C)], _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) {
+  _XCTAssertEqual(expression1, expression2, { $0 == $1 }, message, file: file, line: line)
+}

--- a/Tests/AsyncAlgorithmsTests/TestZip.swift
+++ b/Tests/AsyncAlgorithmsTests/TestZip.swift
@@ -16,24 +16,24 @@ final class TestZip2: XCTestCase {
   func test_zip() async {
     let a = [1, 2, 3]
     let b = ["a", "b", "c"]
-    let expected = Array(zip(a, b)).map { "\($0)" + $1 }
-    let actual = await Array(zip(a.async, b.async)).map { "\($0)" + $1 }
+    let expected = Array(zip(a, b))
+    let actual = await Array(zip(a.async, b.async))
     XCTAssertEqual(expected, actual)
   }
   
   func test_zip_first_longer() async {
     let a = [1, 2, 3, 4, 5]
     let b = ["a", "b", "c"]
-    let expected = Array(zip(a, b)).map { "\($0)" + $1 }
-    let actual = await Array(zip(a.async, b.async)).map { "\($0)" + $1 }
+    let expected = Array(zip(a, b))
+    let actual = await Array(zip(a.async, b.async))
     XCTAssertEqual(expected, actual)
   }
   
   func test_zip_second_longer() async {
     let a = [1, 2, 3]
     let b = ["a", "b", "c", "d", "e"]
-    let expected = Array(zip(a, b)).map { "\($0)" + $1 }
-    let actual = await Array(zip(a.async, b.async)).map { "\($0)" + $1 }
+    let expected = Array(zip(a, b))
+    let actual = await Array(zip(a.async, b.async))
     XCTAssertEqual(expected, actual)
   }
   
@@ -42,11 +42,11 @@ final class TestZip2: XCTestCase {
     let b = ["a", "b", "c"]
     let sequence = zip(a.async, b.async)
     var iterator = sequence.makeAsyncIterator()
-    var collected = [String]()
-    while let (int, str) = await iterator.next() {
-      collected.append("\(int)\(str)")
+    var collected = [(Int, String)]()
+    while let item = await iterator.next() {
+      collected.append(item)
     }
-    XCTAssertEqual(["1a", "2b", "3c"], collected)
+    XCTAssertEqual([(1, "a"), (2, "b"), (3, "c")], collected)
     let pastEnd = await iterator.next()
     XCTAssertNil(pastEnd)
   }
@@ -56,11 +56,11 @@ final class TestZip2: XCTestCase {
     let b = ["a", "b", "c"]
     let sequence = zip(a.async, b.async)
     var iterator = sequence.makeAsyncIterator()
-    var collected = [String]()
-    while let (int, str) = await iterator.next() {
-      collected.append("\(int)\(str)")
+    var collected = [(Int, String)]()
+    while let item = await iterator.next() {
+      collected.append(item)
     }
-    XCTAssertEqual(["1a", "2b", "3c"], collected)
+    XCTAssertEqual([(1, "a"), (2, "b"), (3, "c")], collected)
     let pastEnd = await iterator.next()
     XCTAssertNil(pastEnd)
   }
@@ -70,11 +70,11 @@ final class TestZip2: XCTestCase {
     let b = ["a", "b", "c", "d", "e"]
     let sequence = zip(a.async, b.async)
     var iterator = sequence.makeAsyncIterator()
-    var collected = [String]()
-    while let (int, str) = await iterator.next() {
-      collected.append("\(int)\(str)")
+    var collected = [(Int, String)]()
+    while let item = await iterator.next() {
+      collected.append(item)
     }
-    XCTAssertEqual(["1a", "2b", "3c"], collected)
+    XCTAssertEqual([(1, "a"), (2, "b"), (3, "c")], collected)
     let pastEnd = await iterator.next()
     XCTAssertNil(pastEnd)
   }
@@ -84,16 +84,16 @@ final class TestZip2: XCTestCase {
     let b = ["a", "b", "c"]
     let sequence = zip(a.async.map { try throwOn(2, $0) }, b.async)
     var iterator = sequence.makeAsyncIterator()
-    var collected = [String]()
+    var collected = [(Int, String)]()
     do {
-      while let (int, str) = try await iterator.next() {
-        collected.append("\(int)\(str)")
+      while let item = try await iterator.next() {
+        collected.append(item)
       }
       XCTFail()
     } catch {
       XCTAssertEqual(Failure(), error as? Failure)
     }
-    XCTAssertEqual(["1a"], collected)
+    XCTAssertEqual([(1, "a")], collected)
     let pastEnd = try await iterator.next()
     XCTAssertNil(pastEnd)
   }
@@ -103,16 +103,16 @@ final class TestZip2: XCTestCase {
     let b = ["a", "b", "c"]
     let sequence = zip(a.async, b.async.map { try throwOn("b", $0) })
     var iterator = sequence.makeAsyncIterator()
-    var collected = [String]()
+    var collected = [(Int, String)]()
     do {
-      while let (int, str) = try await iterator.next() {
-        collected.append("\(int)\(str)")
+      while let item = try await iterator.next() {
+        collected.append(item)
       }
       XCTFail()
     } catch {
       XCTAssertEqual(Failure(), error as? Failure)
     }
-    XCTAssertEqual(["1a"], collected)
+    XCTAssertEqual([(1, "a")], collected)
     let pastEnd = try await iterator.next()
     XCTAssertNil(pastEnd)
   }
@@ -147,32 +147,32 @@ final class TestZip3: XCTestCase {
     let a = [1, 2, 3]
     let b = ["a", "b", "c"]
     let c = [1, 2, 3]
-    let actual = await Array(zip(a.async, b.async, c.async)).map { "\($0)" + $1 + "\($2)" }
-    XCTAssertEqual(["1a1", "2b2", "3c3"], actual)
+    let actual = await Array(zip(a.async, b.async, c.async))
+    XCTAssertEqual([(1, "a", 1), (2, "b", 2), (3, "c", 3)], actual)
   }
   
   func test_zip_first_longer() async {
     let a = [1, 2, 3, 4, 5]
     let b = ["a", "b", "c"]
     let c = [1, 2, 3]
-    let actual = await Array(zip(a.async, b.async, c.async)).map { "\($0)" + $1 + "\($2)"}
-    XCTAssertEqual(["1a1", "2b2", "3c3"], actual)
+    let actual = await Array(zip(a.async, b.async, c.async))
+    XCTAssertEqual([(1, "a", 1), (2, "b", 2), (3, "c", 3)], actual)
   }
   
   func test_zip_second_longer() async {
     let a = [1, 2, 3]
     let b = ["a", "b", "c", "d", "e"]
     let c = [1, 2, 3]
-    let actual = await Array(zip(a.async, b.async, c.async)).map { "\($0)" + $1 + "\($2)"  }
-    XCTAssertEqual(["1a1", "2b2", "3c3"], actual)
+    let actual = await Array(zip(a.async, b.async, c.async))
+    XCTAssertEqual([(1, "a", 1), (2, "b", 2), (3, "c", 3)], actual)
   }
   
   func test_zip_third_longer() async {
     let a = [1, 2, 3]
     let b = ["a", "b", "c"]
     let c = [1, 2, 3, 4, 5]
-    let actual = await Array(zip(a.async, b.async, c.async)).map { "\($0)" + $1 + "\($2)" }
-    XCTAssertEqual(["1a1", "2b2", "3c3"], actual)
+    let actual = await Array(zip(a.async, b.async, c.async))
+    XCTAssertEqual([(1, "a", 1), (2, "b", 2), (3, "c", 3)], actual)
   }
   
   func test_iterate_past_end() async {
@@ -181,11 +181,11 @@ final class TestZip3: XCTestCase {
     let c = [1, 2, 3]
     let sequence = zip(a.async, b.async, c.async)
     var iterator = sequence.makeAsyncIterator()
-    var collected = [String]()
-    while let (int1, str, int2) = await iterator.next() {
-      collected.append("\(int1)\(str)\(int2)")
+    var collected = [(Int, String, Int)]()
+    while let item = await iterator.next() {
+      collected.append(item)
     }
-    XCTAssertEqual(["1a1", "2b2", "3c3"], collected)
+    XCTAssertEqual([(1, "a", 1), (2, "b", 2), (3, "c", 3)], collected)
     let pastEnd = await iterator.next()
     XCTAssertNil(pastEnd)
   }
@@ -196,11 +196,11 @@ final class TestZip3: XCTestCase {
     let c = [1, 2, 3]
     let sequence = zip(a.async, b.async, c.async)
     var iterator = sequence.makeAsyncIterator()
-    var collected = [String]()
-    while let (int1, str, int2) = await iterator.next() {
-      collected.append("\(int1)\(str)\(int2)")
+    var collected = [(Int, String, Int)]()
+    while let item = await iterator.next() {
+      collected.append(item)
     }
-    XCTAssertEqual(["1a1", "2b2", "3c3"], collected)
+    XCTAssertEqual([(1, "a", 1), (2, "b", 2), (3, "c", 3)], collected)
     let pastEnd = await iterator.next()
     XCTAssertNil(pastEnd)
   }
@@ -211,11 +211,11 @@ final class TestZip3: XCTestCase {
     let c = [1, 2, 3]
     let sequence = zip(a.async, b.async, c.async)
     var iterator = sequence.makeAsyncIterator()
-    var collected = [String]()
-    while let (int1, str, int2) = await iterator.next() {
-      collected.append("\(int1)\(str)\(int2)")
+    var collected = [(Int, String, Int)]()
+    while let item = await iterator.next() {
+      collected.append(item)
     }
-    XCTAssertEqual(["1a1", "2b2", "3c3"], collected)
+    XCTAssertEqual([(1, "a", 1), (2, "b", 2), (3, "c", 3)], collected)
     let pastEnd = await iterator.next()
     XCTAssertNil(pastEnd)
   }
@@ -226,11 +226,11 @@ final class TestZip3: XCTestCase {
     let c = [1, 2, 3, 4, 5]
     let sequence = zip(a.async, b.async, c.async)
     var iterator = sequence.makeAsyncIterator()
-    var collected = [String]()
-    while let (int1, str, int2) = await iterator.next() {
-      collected.append("\(int1)\(str)\(int2)")
+    var collected = [(Int, String, Int)]()
+    while let item = await iterator.next() {
+      collected.append(item)
     }
-    XCTAssertEqual(["1a1", "2b2", "3c3"], collected)
+    XCTAssertEqual([(1, "a", 1), (2, "b", 2), (3, "c", 3)], collected)
     let pastEnd = await iterator.next()
     XCTAssertNil(pastEnd)
   }
@@ -241,16 +241,16 @@ final class TestZip3: XCTestCase {
     let c = [1, 2, 3]
     let sequence = zip(a.async.map { try throwOn(2, $0) }, b.async, c.async)
     var iterator = sequence.makeAsyncIterator()
-    var collected = [String]()
+    var collected = [(Int, String, Int)]()
     do {
-      while let (int1, str, int2) = try await iterator.next() {
-        collected.append("\(int1)\(str)\(int2)")
+      while let item = try await iterator.next() {
+        collected.append(item)
       }
       XCTFail()
     } catch {
       XCTAssertEqual(Failure(), error as? Failure)
     }
-    XCTAssertEqual(["1a1"], collected)
+    XCTAssertEqual([(1, "a", 1)], collected)
     let pastEnd = try await iterator.next()
     XCTAssertNil(pastEnd)
   }
@@ -261,16 +261,16 @@ final class TestZip3: XCTestCase {
     let c = [1, 2, 3]
     let sequence = zip(a.async, b.async.map { try throwOn("b", $0) }, c.async)
     var iterator = sequence.makeAsyncIterator()
-    var collected = [String]()
+    var collected = [(Int, String, Int)]()
     do {
-      while let (int1, str, int2) = try await iterator.next() {
-        collected.append("\(int1)\(str)\(int2)")
+      while let item = try await iterator.next() {
+        collected.append(item)
       }
       XCTFail()
     } catch {
       XCTAssertEqual(Failure(), error as? Failure)
     }
-    XCTAssertEqual(["1a1"], collected)
+    XCTAssertEqual([(1, "a", 1)], collected)
     let pastEnd = try await iterator.next()
     XCTAssertNil(pastEnd)
   }
@@ -281,16 +281,16 @@ final class TestZip3: XCTestCase {
     let c = [1, 2, 3]
     let sequence = zip(a.async, b.async, c.async.map { try throwOn(2, $0) })
     var iterator = sequence.makeAsyncIterator()
-    var collected = [String]()
+    var collected = [(Int, String, Int)]()
     do {
-      while let (int1, str, int2) = try await iterator.next() {
-        collected.append("\(int1)\(str)\(int2)")
+      while let item = try await iterator.next() {
+        collected.append(item)
       }
       XCTFail()
     } catch {
       XCTAssertEqual(Failure(), error as? Failure)
     }
-    XCTAssertEqual(["1a1"], collected)
+    XCTAssertEqual([(1, "a", 1)], collected)
     let pastEnd = try await iterator.next()
     XCTAssertNil(pastEnd)
   }


### PR DESCRIPTION
This provides assertions for the testing to validate 2/3 member tuples and arrays of those tuples. This is a test only focused change.