### PR TITLE
A combineLatest combinator

### DIFF
--- a/Sources/AsyncAlgorithms/AsyncCombineLatest2Sequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncCombineLatest2Sequence.swift
@@ -1,0 +1,305 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Async Algorithms open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+public func combineLatest<Base1: AsyncSequence, Base2: AsyncSequence>(_ base1: Base1, _ base2: Base2) -> AsyncCombineLatest2Sequence<Base1, Base2> {
+  AsyncCombineLatest2Sequence(base1, base2)
+}
+
+public struct AsyncCombineLatest2Sequence<Base1: AsyncSequence, Base2: AsyncSequence>: Sendable
+  where
+    Base1: Sendable, Base2: Sendable,
+    Base1.Element: Sendable, Base2.Element: Sendable,
+    Base1.AsyncIterator: Sendable, Base2.AsyncIterator: Sendable {
+  let base1: Base1
+  let base2: Base2
+  
+  init(_ base1: Base1, _ base2: Base2) {
+    self.base1 = base1
+    self.base2 = base2
+  }
+}
+
+extension AsyncCombineLatest2Sequence: AsyncSequence {
+  public typealias Element = (Base1.Element, Base2.Element)
+  
+  public struct Iterator: AsyncIteratorProtocol, Sendable {
+    enum Partial: Sendable {
+      case first(Result<Base1.Element?, Error>, Base1.AsyncIterator)
+      case second(Result<Base2.Element?, Error>, Base2.AsyncIterator)
+    }
+    
+    enum State {
+      case initial(Base1.AsyncIterator, Base2.AsyncIterator)
+      case idle(Base1.AsyncIterator, Base2.AsyncIterator, (Base1.Element, Base2.Element))
+      case firstActiveSecondIdle(Task<Partial, Never>, Base2.AsyncIterator, (Base1.Element, Base2.Element))
+      case firstIdleSecondActive(Base1.AsyncIterator, Task<Partial, Never>, (Base1.Element, Base2.Element))
+      case firstTerminalSecondIdle(Base2.AsyncIterator, (Base1.Element, Base2.Element))
+      case firstIdleSecondTerminal(Base1.AsyncIterator, (Base1.Element, Base2.Element))
+      case terminal
+    }
+    
+    var state: State
+    
+    init(_ base1: Base1.AsyncIterator, _ base2: Base2.AsyncIterator) {
+      state = .initial(base1, base2)
+    }
+    
+    public mutating func next() async rethrows -> (Base1.Element, Base2.Element)? {
+      let task1: Task<Partial, Never>
+      let task2: Task<Partial, Never>
+      var current: (Base1.Element, Base2.Element)
+      
+      switch state {
+      case .initial(let iterator1, let iterator2):
+        func iteration(
+          _ group: inout TaskGroup<Partial>,
+          _ value1: inout Base1.Element?,
+          _ value2: inout Base2.Element?,
+          _ iterator1: inout Base1.AsyncIterator?,
+          _ iterator2: inout Base2.AsyncIterator?
+        ) async -> Result<(Base1.Element, Base2.Element)?, Error>? {
+          guard let partial = await group.next() else {
+            return .success(nil)
+          }
+          switch partial {
+          case .first(let res, let iter):
+            switch res {
+            case .success(let value):
+              if let value = value {
+                value1 = value
+                iterator1 = iter
+                return nil
+              } else {
+                group.cancelAll()
+                return .success(nil)
+              }
+            case .failure(let error):
+              group.cancelAll()
+              return .failure(error)
+            }
+          case .second(let res, let iter):
+            switch res {
+            case .success(let value):
+              if let value = value {
+                value2 = value
+                iterator2 = iter
+                return nil
+              } else {
+                group.cancelAll()
+                return .success(nil)
+              }
+            case .failure(let error):
+              group.cancelAll()
+              return .failure(error)
+            }
+          }
+        }
+        
+        let (result, iter1, iter2) = await withTaskGroup(of: Partial.self) { group -> (Result<(Base1.Element, Base2.Element)?, Error>, Base1.AsyncIterator?, Base2.AsyncIterator?) in
+          group.addTask {
+            var iterator = iterator1
+            do {
+              let value = try await iterator.next()
+              return .first(.success(value), iterator)
+            } catch {
+              return .first(.failure(error), iterator)
+            }
+          }
+          group.addTask {
+            var iterator = iterator2
+            do {
+              let value = try await iterator.next()
+              return .second(.success(value), iterator)
+            } catch {
+              return .second(.failure(error), iterator)
+            }
+          }
+          
+          var res1: Base1.Element?
+          var res2: Base2.Element?
+          var iter1: Base1.AsyncIterator?
+          var iter2: Base2.AsyncIterator?
+          
+          if let result = await iteration(&group, &res1, &res2, &iter1, &iter2) {
+            return (result, nil, nil)
+          }
+          if let result = await iteration(&group, &res1, &res2, &iter1, &iter2) {
+            return (result, nil, nil)
+          }
+          guard let res1 = res1, let res2 = res2 else {
+            return (.success(nil), nil, nil)
+          }
+          
+          return (.success((res1, res2)), iter1, iter2)
+        }
+        do {
+          // make sure to get the result first just in case it has a failure embedded
+          guard let value = try result._rethrowGet() else {
+            state = .terminal
+            return nil
+          }
+          guard let iter1 = iter1, let iter2 = iter2 else {
+            state = .terminal
+            return nil
+          }
+          state = .idle(iter1, iter2, value)
+          return value
+        } catch {
+          state = .terminal
+          throw error
+        }
+      case .idle(let iterator1, let iterator2, let value):
+        task1 = Task {
+          var iterator = iterator1
+          do {
+            let value = try await iterator.next()
+            return .first(.success(value), iterator)
+          } catch {
+            return .first(.failure(error), iterator)
+          }
+        }
+        task2 = Task {
+          var iterator = iterator2
+          do {
+            let value = try await iterator.next()
+            return .second(.success(value), iterator)
+          } catch {
+            return .second(.failure(error), iterator)
+          }
+        }
+        current = value
+      case .firstActiveSecondIdle(let task, let iterator2, let value):
+        task1 = task
+        task2 = Task {
+          var iterator = iterator2
+          do {
+            let value = try await iterator.next()
+            return .second(.success(value), iterator)
+          } catch {
+            return .second(.failure(error), iterator)
+          }
+        }
+        current = value
+      case .firstIdleSecondActive(let iterator1, let task, let value):
+        task1 = Task {
+          var iterator = iterator1
+          do {
+            let value = try await iterator.next()
+            return .first(.success(value), iterator)
+          } catch {
+            return .first(.failure(error), iterator)
+          }
+        }
+        task2 = task
+        current = value
+      case .firstTerminalSecondIdle(var iterator, var current):
+        do {
+          guard let member = try await iterator.next() else {
+            state = .terminal
+            return nil
+          }
+          current.1 = member
+          state = .firstTerminalSecondIdle(iterator, current)
+          return current
+        } catch {
+          state = .terminal
+          throw error
+        }
+      case .firstIdleSecondTerminal(var iterator, var current):
+        do {
+          guard let member = try await iterator.next() else {
+            state = .terminal
+            return nil
+          }
+          current.0 = member
+          state = .firstIdleSecondTerminal(iterator, current)
+          return current
+        } catch {
+          state = .terminal
+          throw error
+        }
+      case .terminal:
+        return nil
+      }
+      switch await Task.select(task1, task2).value {
+      case .first(let result, let iterator):
+        switch result {
+        case .success(let member):
+          if let member = member {
+            current.0 = member
+            state = .firstIdleSecondActive(iterator, task2, current)
+          } else {
+            switch await task2.value {
+            case .first:
+              fatalError()
+            case .second(let result, let iterator):
+              switch result {
+              case .success(let member):
+                if let member = member {
+                  current.1 = member
+                  state = .firstTerminalSecondIdle(iterator, current)
+                  return current
+                } else {
+                  state = .terminal
+                  return nil
+                }
+              case .failure:
+                state = .terminal
+                try result._rethrowError()
+              }
+            }
+          }
+        case .failure:
+          state = .terminal
+          task2.cancel()
+          try result._rethrowError()
+        }
+      case .second(let result, let iterator):
+        switch result {
+        case .success(let member):
+          if let member = member {
+            current.1 = member
+            state = .firstActiveSecondIdle(task1, iterator, current)
+          } else {
+            switch await task1.value {
+            case .first(let result, let iterator):
+              switch result {
+              case .success(let member):
+                if let member = member {
+                  current.0 = member
+                  state = .firstIdleSecondTerminal(iterator, current)
+                  return current
+                } else {
+                  state = .terminal
+                  return nil
+                }
+              case .failure:
+                state = .terminal
+                try result._rethrowError()
+              }
+            case .second:
+              fatalError()
+            }
+          }
+        case .failure:
+          state = .terminal
+          task2.cancel()
+          try result._rethrowError()
+        }
+      }
+      return current
+    }
+  }
+  
+  public func makeAsyncIterator() -> Iterator {
+    Iterator(base1.makeAsyncIterator(), base2.makeAsyncIterator())
+  }
+}

--- a/Sources/AsyncAlgorithms/AsyncCombineLatest3Sequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncCombineLatest3Sequence.swift
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Async Algorithms open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+public func combineLatest<Base1: AsyncSequence, Base2: AsyncSequence, Base3: AsyncSequence>(_ base1: Base1, _ base2: Base2, _ base3: Base3) -> AsyncCombineLatest3Sequence<Base1, Base2, Base3> {
+  AsyncCombineLatest3Sequence(base1, base2, base3)
+}
+
+public struct AsyncCombineLatest3Sequence<Base1: AsyncSequence, Base2: AsyncSequence, Base3: AsyncSequence>
+  where
+    Base1: Sendable, Base2: Sendable, Base3: Sendable,
+    Base1.Element: Sendable, Base2.Element: Sendable, Base3.Element: Sendable,
+    Base1.AsyncIterator: Sendable, Base2.AsyncIterator: Sendable, Base3.AsyncIterator: Sendable {
+  let base1: Base1
+  let base2: Base2
+  let base3: Base3
+  
+  init(_ base1: Base1, _ base2: Base2, _ base3: Base3) {
+    self.base1 = base1
+    self.base2 = base2
+    self.base3 = base3
+  }
+}
+
+extension AsyncCombineLatest3Sequence: AsyncSequence {
+  public typealias Element = (Base1.Element, Base2.Element, Base3.Element)
+  
+  public struct Iterator: AsyncIteratorProtocol {
+    var iterator: AsyncCombineLatest2Sequence<AsyncCombineLatest2Sequence<Base1, Base2>, Base3>.Iterator
+    
+    init(_ base1: Base1.AsyncIterator, _ base2: Base2.AsyncIterator, _ base3: Base3.AsyncIterator) {
+      iterator = AsyncCombineLatest2Sequence<AsyncCombineLatest2Sequence<Base1, Base2>, Base3>.Iterator(AsyncCombineLatest2Sequence<Base1, Base2>.Iterator(base1, base2), base3)
+    }
+    
+    public mutating func next() async rethrows -> (Base1.Element, Base2.Element, Base3.Element)? {
+      guard let value = try await iterator.next() else {
+        return nil
+      }
+      return (value.0.0, value.0.1, value.1)
+    }
+  }
+  
+  public func makeAsyncIterator() -> Iterator {
+    Iterator(base1.makeAsyncIterator(), base2.makeAsyncIterator(), base3.makeAsyncIterator())
+  }
+}

--- a/Tests/AsyncAlgorithmsTests/TestCombineLatest.swift
+++ b/Tests/AsyncAlgorithmsTests/TestCombineLatest.swift
@@ -1,0 +1,388 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Async Algorithms open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import AsyncAlgorithms
+
+final class TestCombineLatest2: XCTestCase {
+  func test_combineLatest() async {
+    let a = [1, 2, 3]
+    let b = ["a", "b", "c"]
+    let sequence = combineLatest(a.async, b.async)
+    let actual = await Array(sequence)
+    XCTAssertGreaterThanOrEqual(actual.count, 3)
+    XCTAssertEqual(actual.first!, (1, "a"))
+  }
+  
+  func test_throwing_combineLatest1() async {
+    let a = [1, 2, 3]
+    let b = ["a", "b", "c"]
+    let sequence = combineLatest(a.async.map { try throwOn(1, $0) }, b.async)
+    var iterator = sequence.makeAsyncIterator()
+    do {
+      let value = try await iterator.next()
+      XCTFail("got \(value as Any) but expected throw")
+    } catch {
+      XCTAssertEqual(error as? Failure, Failure())
+    }
+  }
+  
+  func test_throwing_combineLatest2() async {
+    let a = [1, 2, 3]
+    let b = ["a", "b", "c"]
+    let sequence = combineLatest(a.async, b.async.map { try throwOn("a", $0) })
+    var iterator = sequence.makeAsyncIterator()
+    do {
+      let value = try await iterator.next()
+      XCTFail("got \(value as Any) but expected throw")
+    } catch {
+      XCTAssertEqual(error as? Failure, Failure())
+    }
+  }
+  
+  func test_ordering1() async {
+    var a = GatedSequence([1, 2, 3])
+    var b = GatedSequence(["a", "b", "c"])
+    let finished = expectation(description: "finished")
+    let sequence = combineLatest(a, b)
+    let validator = Validator<(Int, String)>()
+    validator.test(sequence) { iterator in
+      let pastEnd = await iterator.next()
+      XCTAssertNil(pastEnd)
+      finished.fulfill()
+    }
+    var value = await validator.validate()
+    XCTAssertEqual(value, [])
+    a.advance()
+    value = validator.current
+    XCTAssertEqual(value, [])
+    b.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a")])
+    a.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a"), (2, "a")])
+    b.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a"), (2, "a"), (2, "b")])
+    a.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a"), (2, "a"), (2, "b"), (3, "b")])
+    b.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a"), (2, "a"), (2, "b"), (3, "b"), (3, "c")])
+    
+    wait(for: [finished], timeout: 1.0)
+    value = validator.current
+    XCTAssertEqual(value, [(1, "a"), (2, "a"), (2, "b"), (3, "b"), (3, "c")])
+  }
+  
+  func test_ordering2() async {
+    var a = GatedSequence([1, 2, 3])
+    var b = GatedSequence(["a", "b", "c"])
+    let finished = expectation(description: "finished")
+    let sequence = combineLatest(a, b)
+    let validator = Validator<(Int, String)>()
+    validator.test(sequence) { iterator in
+      let pastEnd = await iterator.next()
+      XCTAssertNil(pastEnd)
+      finished.fulfill()
+    }
+    var value = await validator.validate()
+    XCTAssertEqual(value, [])
+    a.advance()
+    value = validator.current
+    XCTAssertEqual(value, [])
+    b.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a")])
+    b.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a"), (1, "b")])
+    a.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a"), (1, "b"), (2, "b")])
+    b.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a"), (1, "b"), (2, "b"), (2, "c")])
+    a.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a"), (1, "b"), (2, "b"), (2, "c"), (3, "c")])
+    
+    wait(for: [finished], timeout: 1.0)
+    value = validator.current
+    XCTAssertEqual(value, [(1, "a"), (1, "b"), (2, "b"), (2, "c"), (3, "c")])
+  }
+  
+  func test_ordering3() async {
+    var a = GatedSequence([1, 2, 3])
+    var b = GatedSequence(["a", "b", "c"])
+    let finished = expectation(description: "finished")
+    let sequence = combineLatest(a, b)
+    let validator = Validator<(Int, String)>()
+    validator.test(sequence) { iterator in
+      let pastEnd = await iterator.next()
+      XCTAssertNil(pastEnd)
+      finished.fulfill()
+    }
+    var value = await validator.validate()
+    XCTAssertEqual(value, [])
+    a.advance()
+    value = validator.current
+    XCTAssertEqual(value, [])
+    b.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a")])
+    a.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a"), (2, "a")])
+    a.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a"), (2, "a"), (3, "a")])
+    b.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a"), (2, "a"), (3, "a"), (3, "b")])
+    b.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a"), (2, "a"), (3, "a"), (3, "b"), (3, "c")])
+    
+    wait(for: [finished], timeout: 1.0)
+    value = validator.current
+    XCTAssertEqual(value, [(1, "a"), (2, "a"), (3, "a"), (3, "b"), (3, "c")])
+  }
+  
+  func test_ordering4() async {
+    var a = GatedSequence([1, 2, 3])
+    var b = GatedSequence(["a", "b", "c"])
+    let finished = expectation(description: "finished")
+    let sequence = combineLatest(a, b)
+    let validator = Validator<(Int, String)>()
+    validator.test(sequence) { iterator in
+      let pastEnd = await iterator.next()
+      XCTAssertNil(pastEnd)
+      finished.fulfill()
+    }
+    var value = await validator.validate()
+    XCTAssertEqual(value, [])
+    a.advance()
+    value = validator.current
+    XCTAssertEqual(value, [])
+    b.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a")])
+    b.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a"), (1, "b")])
+    b.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a"), (1, "b"), (1, "c")])
+    a.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a"), (1, "b"), (1, "c"), (2, "c")])
+    a.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a"), (1, "b"), (1, "c"), (2, "c"), (3, "c")])
+    
+    wait(for: [finished], timeout: 1.0)
+    value = validator.current
+    XCTAssertEqual(value, [(1, "a"), (1, "b"), (1, "c"), (2, "c"), (3, "c")])
+  }
+  
+  func test_throwing_ordering1() async {
+    var a = GatedSequence([1, 2, 3])
+    var b = GatedSequence(["a", "b", "c"])
+    let finished = expectation(description: "finished")
+    let sequence = combineLatest(a.map { try throwOn(2, $0) }, b)
+    let validator = Validator<(Int, String)>()
+    validator.test(sequence) { iterator in
+      do {
+        let pastEnd = try await iterator.next()
+        XCTAssertNil(pastEnd)
+      } catch {
+        XCTFail()
+      }
+      finished.fulfill()
+    }
+    var value = await validator.validate()
+    XCTAssertEqual(value, [])
+    a.advance()
+    value = validator.current
+    XCTAssertEqual(value, [])
+    b.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a")])
+    b.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a"), (1, "b")])
+    a.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a"), (1, "b")])
+    
+    XCTAssertEqual(validator.failure as? Failure, Failure())
+    
+    wait(for: [finished], timeout: 1.0)
+    value = validator.current
+    XCTAssertEqual(value, [(1, "a"), (1, "b")])
+  }
+  
+  func test_throwing_ordering2() async {
+    var a = GatedSequence([1, 2, 3])
+    var b = GatedSequence(["a", "b", "c"])
+    let finished = expectation(description: "finished")
+    let sequence = combineLatest(a, b.map { try throwOn("b", $0) })
+    let validator = Validator<(Int, String)>()
+    validator.test(sequence) { iterator in
+      do {
+        let pastEnd = try await iterator.next()
+        XCTAssertNil(pastEnd)
+      } catch {
+        XCTFail()
+      }
+      finished.fulfill()
+    }
+    var value = await validator.validate()
+    XCTAssertEqual(value, [])
+    a.advance()
+    value = validator.current
+    XCTAssertEqual(value, [])
+    b.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a")])
+    a.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a"), (2, "a")])
+    b.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a"), (2, "a")])
+    
+    XCTAssertEqual(validator.failure as? Failure, Failure())
+    
+    wait(for: [finished], timeout: 1.0)
+    value = validator.current
+    XCTAssertEqual(value, [(1, "a"), (2, "a")])
+  }
+  
+  func test_cancellation() async {
+    let source1 = Indefinite(value: "test1")
+    let source2 = Indefinite(value: "test2")
+    let sequence = combineLatest(source1.async, source2.async)
+    let finished = expectation(description: "finished")
+    let iterated = expectation(description: "iterated")
+    let task = Task {
+      var firstIteration = false
+      for await _ in sequence {
+        if !firstIteration {
+          firstIteration = true
+          iterated.fulfill()
+        }
+      }
+      finished.fulfill()
+    }
+    // ensure the other task actually starts
+    wait(for: [iterated], timeout: 1.0)
+    // cancellation should ensure the loop finishes
+    // without regards to the remaining underlying sequence
+    task.cancel()
+    wait(for: [finished], timeout: 1.0)
+  }
+}
+
+final class TestCombineLatest3: XCTestCase {
+  func test_combineLatest() async {
+    let a = [1, 2, 3]
+    let b = ["a", "b", "c"]
+    let c = [4, 5, 6]
+    let sequence = combineLatest(a.async, b.async, c.async)
+    let actual = await Array(sequence)
+    XCTAssertGreaterThanOrEqual(actual.count, 3)
+    XCTAssertEqual(actual.first!, (1, "a", 4))
+  }
+  
+  func test_ordering1() async {
+    var a = GatedSequence([1, 2, 3])
+    var b = GatedSequence(["a", "b", "c"])
+    var c = GatedSequence([4, 5, 6])
+    let finished = expectation(description: "finished")
+    let sequence = combineLatest(a, b, c)
+    let validator = Validator<(Int, String, Int)>()
+    validator.test(sequence) { iterator in
+      let pastEnd = await iterator.next()
+      XCTAssertNil(pastEnd)
+      finished.fulfill()
+    }
+    var value = await validator.validate()
+    XCTAssertEqual(value, [])
+    a.advance()
+    value = validator.current
+    XCTAssertEqual(value, [])
+    b.advance()
+    value = validator.current
+    XCTAssertEqual(value, [])
+    c.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a", 4)])
+    a.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a", 4), (2, "a", 4)])
+    b.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a", 4), (2, "a", 4), (2, "b", 4)])
+    c.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a", 4), (2, "a", 4), (2, "b", 4), (2, "b", 5)])
+    a.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a", 4), (2, "a", 4), (2, "b", 4), (2, "b", 5), (3, "b", 5)])
+    b.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a", 4), (2, "a", 4), (2, "b", 4), (2, "b", 5), (3, "b", 5), (3, "c", 5)])
+    c.advance()
+    
+    value = await validator.validate()
+    XCTAssertEqual(value, [(1, "a", 4), (2, "a", 4), (2, "b", 4), (2, "b", 5), (3, "b", 5), (3, "c", 5), (3, "c", 6)])
+
+    wait(for: [finished], timeout: 1.0)
+    value = validator.current
+    XCTAssertEqual(value, [(1, "a", 4), (2, "a", 4), (2, "b", 4), (2, "b", 5), (3, "b", 5), (3, "c", 5), (3, "c", 6)])
+  }
+}


### PR DESCRIPTION
This is similar to the behavior of zip by combining two or more async sequences into a tuple result, but instead of waiting on each side to produce a value it emits tuples of combined values on every time it updates any side.

This includes a new manual verifier stepwise testing mechanism to validate the order of events being fed into operators or combinators.

The code size for the 3 sided combineLatest grew so large that it became untenable - so this takes a compositional approach to the iterators.