### PR TITLE
[NFC] Fixup attribution dates in comments

### DIFF
--- a/Sources/AsyncAlgorithms/Dictionary.swift
+++ b/Sources/AsyncAlgorithms/Dictionary.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Async Algorithms open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/AsyncAlgorithms/RangeReplaceableCollection.swift
+++ b/Sources/AsyncAlgorithms/RangeReplaceableCollection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Async Algorithms open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/AsyncAlgorithms/Rethrow.swift
+++ b/Sources/AsyncAlgorithms/Rethrow.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Async Algorithms open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Sources/AsyncAlgorithms/SetAlgebra.swift
+++ b/Sources/AsyncAlgorithms/SetAlgebra.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Async Algorithms open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Tests/AsyncAlgorithmsTests/TestChain.swift
+++ b/Tests/AsyncAlgorithmsTests/TestChain.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Async Algorithms open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Tests/AsyncAlgorithmsTests/TestDictionary.swift
+++ b/Tests/AsyncAlgorithmsTests/TestDictionary.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Async Algorithms open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Tests/AsyncAlgorithmsTests/TestRangeReplacableCollection.swift
+++ b/Tests/AsyncAlgorithmsTests/TestRangeReplacableCollection.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Async Algorithms open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Tests/AsyncAlgorithmsTests/TestSetAlgebra.swift
+++ b/Tests/AsyncAlgorithmsTests/TestSetAlgebra.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Async Algorithms open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information

--- a/Tests/AsyncAlgorithmsTests/TestZip.swift
+++ b/Tests/AsyncAlgorithmsTests/TestZip.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Async Algorithms open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information


### PR DESCRIPTION
Some of the dates in comments were from earlier work. This updates to the right date.