### PR TITLE
Add marble diagrams for merge and correct partial state transitions

### DIFF
--- a/Tests/AsyncAlgorithmsTests/TestMerge.swift
+++ b/Tests/AsyncAlgorithmsTests/TestMerge.swift
@@ -123,6 +123,15 @@ final class TestMerge2: XCTestCase {
     XCTAssertNil(pastEnd)
   }
   
+  func test_diagram() {
+    marbleDiagram {
+      "a-c-e-g-|"
+      "-b-d-f-h"
+      merge($0.inputs[0], $0.inputs[1])
+      "abcdefgh|"
+    }
+  }
+  
   func test_cancellation() async {
     let source1 = Indefinite(value: "test1")
     let source2 = Indefinite(value: "test2")
@@ -299,6 +308,16 @@ final class TestMerge3: XCTestCase {
     XCTAssertEqual(collected.intersection([7, 8, 9]), Set([7, 8, 9]))
     let pastEnd = try await iterator.next()
     XCTAssertNil(pastEnd)
+  }
+  
+  func test_diagram() {
+    marbleDiagram {
+      "a---e---|"
+      "-b-d-f-h|"
+      "--c---g-|"
+      merge($0.inputs[0], $0.inputs[1], $0.inputs[2])
+      "abcdefgh|"
+    }
   }
 
   func test_cancellation() async {


### PR DESCRIPTION
This is partial scheduling corrections for races of state transitions of merge.

When the apply hits the state must be claimed as partial; else the applied tasks may be lost in the transition (specifically this is exposed in cases where the underlying thread scheduling becomes bound to one thread). The execution scheduling with the marble diagrams exposes this immediately.

The same approach applies to both 2 and 3 versions of merge.

This is dependent upon https://github.com/apple/swift-async-algorithms/pull/40