### PR TITLE
implement a sequence for debouncing incoming events to an expected quiescence duration

### DIFF
--- a/Sources/AsyncAlgorithms/AsyncDebounceSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncDebounceSequence.swift
@@ -81,6 +81,7 @@ extension AsyncDebounceSequence: AsyncSequence {
         case .produce(let result, let iter):
           lastResult = result
           last = clock.now
+          sleep.cancel()
           self.iterator = iter
           switch result {
           case .success(let value):

--- a/Tests/AsyncAlgorithmsTests/TestDebounce.swift
+++ b/Tests/AsyncAlgorithmsTests/TestDebounce.swift
@@ -20,6 +20,15 @@ final class TestDebounce: XCTestCase {
       "------d----e-----g-|"
     }
   }
+
+  func test_delayingValues_dangling_last() {
+    validate {
+      "abcd----e---f-g-|"
+      $0.inputs[0].debounce(for: .steps(3), clock: $0.clock)
+      "------d----e----|"
+    }
+  }
+
   
   func test_finishDoesntDebounce() {
     validate {


### PR DESCRIPTION
This brings in a new operation on AsyncSequence to rate limit events - by debouncing events to an expected quiescence duration.