### PR TITLE
Validate AsyncSequence specification

### DIFF
--- a/Sources/AsyncSequenceValidation/Expectation.swift
+++ b/Sources/AsyncSequenceValidation/Expectation.swift
@@ -30,6 +30,9 @@ extension AsyncSequenceValidationDiagram {
       case unexpectedValue(String)
       case unexpectedFinish
       case unexpectedFailure(Error)
+      
+      case specificationViolationGotValueAfterIteration(String)
+      case specificationViolationGotFailureAfterIteration(Error)
     }
     public var when: Clock.Instant
     public var kind: Kind
@@ -62,6 +65,10 @@ extension AsyncSequenceValidationDiagram {
         return "unexpected finish"
       case .unexpectedFailure:
         return "unexpected failure"
+      case .specificationViolationGotValueAfterIteration(let actual):
+        return "specification violation got \"\(actual)\" after iteration terminated"
+      case .specificationViolationGotFailureAfterIteration(let error):
+        return "specification violation got failure after iteration terminated"
       }
     }
     

--- a/Sources/AsyncSequenceValidation/WorkQueue.swift
+++ b/Sources/AsyncSequenceValidation/WorkQueue.swift
@@ -239,7 +239,7 @@ struct WorkQueue: Sendable {
       }
       if state.items[token]?.isCancelled == true {
         let item: Item = .work(token, {
-          continuation.resume(throwing: CancellationError())
+          continuation.resume(returning: nil) // the input sequences should not throw cancellation errors
         })
         state.queues[job, default: []].append(item)
         state.items[token] = item

--- a/Tests/AsyncAlgorithmsTests/Support/ViolatingSequence.swift
+++ b/Tests/AsyncAlgorithmsTests/Support/ViolatingSequence.swift
@@ -1,0 +1,73 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Async Algorithms open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+extension AsyncSequence {
+  func violatingSpecification(returningPastEndIteration element: Element) -> SpecificationViolatingSequence<Self> {
+    SpecificationViolatingSequence(self, kind: .producing(element))
+  }
+  
+  func violatingSpecification(throwingPastEndIteration error: Error) -> SpecificationViolatingSequence<Self> {
+    SpecificationViolatingSequence(self, kind: .throwing(error))
+  }
+}
+
+struct SpecificationViolatingSequence<Base: AsyncSequence> {
+  enum Kind {
+    case producing(Base.Element)
+    case throwing(Error)
+  }
+  
+  let base: Base
+  let kind: Kind
+  
+  init(_ base: Base, kind: Kind) {
+    self.base = base
+    self.kind = kind
+  }
+}
+
+extension SpecificationViolatingSequence: AsyncSequence {
+  typealias Element = Base.Element
+  
+  struct Iterator: AsyncIteratorProtocol {
+    var iterator: Base.AsyncIterator
+    let kind: Kind
+    var finished = false
+    var violated = false
+    
+    mutating func next() async throws -> Element? {
+      if finished {
+        if violated {
+          return nil
+        }
+        violated = true
+        switch kind {
+        case .producing(let element): return element
+        case .throwing(let error): throw error
+        }
+      }
+      do {
+        if let value = try await iterator.next() {
+          return value
+        }
+        finished = true
+        return nil
+      } catch {
+        finished = true
+        throw error
+      }
+    }
+  }
+  
+  func makeAsyncIterator() -> Iterator {
+    Iterator(iterator: base.makeAsyncIterator(), kind: kind)
+  }
+}

--- a/Tests/AsyncAlgorithmsTests/TestValidationTests.swift
+++ b/Tests/AsyncAlgorithmsTests/TestValidationTests.swift
@@ -232,4 +232,22 @@ final class TestValidationDiagram: XCTestCase {
       "[a-]b|"
     }
   }
+  
+  func test_diagram_specification_produce_past_end() {
+    expectFailures(["specification violation got \"d\" after iteration terminated at tick 9"])
+    validate {
+      "a--b--c--|"
+      $0.inputs[0].violatingSpecification(returningPastEndIteration: "d")
+      "a--b--c--|"
+    }
+  }
+  
+  func test_diagram_specification_throw_past_end() {
+    expectFailures(["specification violation got failure after iteration terminated at tick 9"])
+    validate {
+      "a--b--c--|"
+      $0.inputs[0].violatingSpecification(throwingPastEndIteration: Failure())
+      "a--b--c--|"
+    }
+  }
 }


### PR DESCRIPTION
https://forums.swift.org/t/pitch-clarify-end-of-iteration-behavior-for-asyncsequence/45548 concretized the behavior expected of terminal states of `AsyncSequence`. This makes the validation diagrams enforce that expectation via assertions.