### PR TITLE
[Naming Adjustment] Rename to AsyncChannel

### DIFF
--- a/Sources/AsyncAlgorithms/AsyncChannel.swift
+++ b/Sources/AsyncAlgorithms/AsyncChannel.swift
@@ -9,24 +9,24 @@
 //
 //===----------------------------------------------------------------------===//
 
-public final class AsyncSubject<Element: Sendable>: AsyncSequence, Sendable {
+public final class AsyncChannel<Element: Sendable>: AsyncSequence, Sendable {
   public struct Iterator: AsyncIteratorProtocol, Sendable {
-    let subject: AsyncSubject<Element>
+    let channel: AsyncChannel<Element>
     var active: Bool = true
     
-    init(_ subject: AsyncSubject<Element>) {
-      self.subject = subject
+    init(_ channel: AsyncChannel<Element>) {
+      self.channel = channel
     }
     
     public mutating func next() async -> Element? {
       guard active else {
         return nil
       }
-      let generation = subject.establish()
-      let value: Element? = await withTaskCancellationHandler { [subject] in
-          subject.cancel(generation)
+      let generation = channel.establish()
+      let value: Element? = await withTaskCancellationHandler { [channel] in
+        channel.cancel(generation)
       } operation: {
-        await subject.next(generation)
+        await channel.next(generation)
       }
       
       if let value = value {

--- a/Sources/AsyncAlgorithms/AsyncThrowingChannel.swift
+++ b/Sources/AsyncAlgorithms/AsyncThrowingChannel.swift
@@ -9,25 +9,25 @@
 //
 //===----------------------------------------------------------------------===//
 
-public final class AsyncThrowingSubject<Element: Sendable, Failure: Error>: AsyncSequence, Sendable {
+public final class AsyncThrowingChannel<Element: Sendable, Failure: Error>: AsyncSequence, Sendable {
   public struct Iterator: AsyncIteratorProtocol, Sendable {
-    let subject: AsyncThrowingSubject<Element, Failure>
+    let channel: AsyncThrowingChannel<Element, Failure>
     var active: Bool = true
     
-    init(_ subject: AsyncThrowingSubject<Element, Failure>) {
-      self.subject = subject
+    init(_ channel: AsyncThrowingChannel<Element, Failure>) {
+      self.channel = channel
     }
     
     public mutating func next() async throws -> Element? {
       guard active else {
         return nil
       }
-      let generation = subject.establish()
+      let generation = channel.establish()
       do {
-        let value: Element? = try await withTaskCancellationHandler { [subject] in
-            subject.cancel(generation)
+        let value: Element? = try await withTaskCancellationHandler { [channel] in
+          channel.cancel(generation)
         } operation: {
-          try await subject.next(generation)
+          try await channel.next(generation)
         }
         
         if let value = value {

--- a/Tests/AsyncAlgorithmsTests/TestChannel.swift
+++ b/Tests/AsyncAlgorithmsTests/TestChannel.swift
@@ -12,43 +12,43 @@
 import XCTest
 import AsyncAlgorithms
 
-final class TestSubject: XCTestCase {
-  func test_subject() async {
-    let subject = AsyncSubject<String>()
+final class TestChannel: XCTestCase {
+  func test_channel() async {
+    let channel = AsyncChannel<String>()
     Task {
-      await subject.send("test1")
+      await channel.send("test1")
     }
     Task {
-      await subject.send("test2")
+      await channel.send("test2")
     }
     
     let t: Task<String?, Never> = Task {
-      var iterator = subject.makeAsyncIterator()
+      var iterator = channel.makeAsyncIterator()
       let value = await iterator.next()
       return value
     }
-    var iterator = subject.makeAsyncIterator()
+    var iterator = channel.makeAsyncIterator()
     let value = await iterator.next()
     let other = await t.value
     
     XCTAssertEqual(Set([value, other]), Set(["test1", "test2"]))
   }
   
-  func test_throwing_subject() async throws {
-    let subject = AsyncThrowingSubject<String, Error>()
+  func test_throwing_channel() async throws {
+    let channel = AsyncThrowingChannel<String, Error>()
     Task {
-      await subject.send("test1")
+      await channel.send("test1")
     }
     Task {
-      await subject.send("test2")
+      await channel.send("test2")
     }
     
     let t: Task<String?, Error> = Task {
-      var iterator = subject.makeAsyncIterator()
+      var iterator = channel.makeAsyncIterator()
       let value = try await iterator.next()
       return value
     }
-    var iterator = subject.makeAsyncIterator()
+    var iterator = channel.makeAsyncIterator()
     let value = try await iterator.next()
     let other = try await t.value
     
@@ -56,11 +56,11 @@ final class TestSubject: XCTestCase {
   }
   
   func test_throwing() async {
-    let subject = AsyncThrowingSubject<String, Error>()
+    let channel = AsyncThrowingChannel<String, Error>()
     Task {
-      await subject.fail(Failure())
+      await channel.fail(Failure())
     }
-    var iterator = subject.makeAsyncIterator()
+    var iterator = channel.makeAsyncIterator()
     do {
       let _ = try await iterator.next()
       XCTFail()
@@ -70,11 +70,11 @@ final class TestSubject: XCTestCase {
   }
   
   func test_send_finish() async {
-    let subject = AsyncSubject<String>()
+    let channel = AsyncChannel<String>()
     let complete = ManagedCriticalState(false)
     let finished = expectation(description: "finished")
     Task {
-      await subject.finish()
+      await channel.finish()
       complete.withCriticalRegion { $0 = true }
       finished.fulfill()
     }
@@ -83,7 +83,7 @@ final class TestSubject: XCTestCase {
     let received = expectation(description: "received")
     let pastEnd = expectation(description: "pastEnd")
     Task {
-      var iterator = subject.makeAsyncIterator()
+      var iterator = channel.makeAsyncIterator()
       let ending = await iterator.next()
       value.withCriticalRegion { $0 = ending }
       received.fulfill()
@@ -97,17 +97,17 @@ final class TestSubject: XCTestCase {
     wait(for: [pastEnd], timeout: 1.0)
     let additionalSend = expectation(description: "additional send")
     Task {
-      await subject.send("test")
+      await channel.send("test")
       additionalSend.fulfill()
     }
     wait(for: [additionalSend], timeout: 1.0)
   }
   
   func test_cancellation() async {
-    let subject = AsyncSubject<String>()
+    let channel = AsyncChannel<String>()
     let ready = expectation(description: "ready")
     let task: Task<String?, Never> = Task {
-      var iterator = subject.makeAsyncIterator()
+      var iterator = channel.makeAsyncIterator()
       ready.fulfill()
       return await iterator.next()
     }
@@ -118,10 +118,10 @@ final class TestSubject: XCTestCase {
   }
   
   func test_cancellation_throwing() async throws {
-    let subject = AsyncThrowingSubject<String, Error>()
+    let channel = AsyncThrowingChannel<String, Error>()
     let ready = expectation(description: "ready")
     let task: Task<String?, Error> = Task {
-      var iterator = subject.makeAsyncIterator()
+      var iterator = channel.makeAsyncIterator()
       ready.fulfill()
       return try await iterator.next()
     }


### PR DESCRIPTION
Subject was a provisional name, and AsyncChannel has a much better ring to it. The name still needs to be discussed at large with the community but this is a better starting point.