### PR TITLE
Add a static method for constructing timers

### DIFF
--- a/Sources/AsyncAlgorithms/AsyncTimerSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncTimerSequence.swift
@@ -67,5 +67,19 @@ public struct AsyncTimerSequence<C: Clock>: AsyncSequence {
   }
 }
 
+extension AsyncTimerSequence {
+  public static func repeating(every interval: C.Instant.Duration, tolerance: C.Instant.Duration? = nil, clock: C) -> AsyncTimerSequence<C> {
+    return AsyncTimerSequence(interval: interval, tolerance: tolerance, clock: clock)
+  }
+}
+
+/*
+extension AsyncTimerSequence where C == SuspendingClock {
+  public static func repeating(every interval: Duration, tolerance: Duration? = nil) -> AsyncTimerSequence<SuspendingClock> {
+    return AsyncTimerSequence(interval: interval, tolerance: tolerance, clock: SuspendingClock())
+  }
+}
+*/
+
 extension AsyncTimerSequence: Sendable { }
 extension AsyncTimerSequence.Iterator: Sendable { }


### PR DESCRIPTION
This shorthand is useful for cases like `chunked(by: .repeating(every: .seconds(3)))`.