### PR TITLE
Reduce warnings from preconcurrency issues and unused values

### DIFF
--- a/Sources/AsyncSequenceValidation/Expectation.swift
+++ b/Sources/AsyncSequenceValidation/Expectation.swift
@@ -67,7 +67,7 @@ extension AsyncSequenceValidationDiagram {
         return "unexpected failure"
       case .specificationViolationGotValueAfterIteration(let actual):
         return "specification violation got \"\(actual)\" after iteration terminated"
-      case .specificationViolationGotFailureAfterIteration(let error):
+      case .specificationViolationGotFailureAfterIteration:
         return "specification violation got failure after iteration terminated"
       }
     }

--- a/Tests/AsyncAlgorithmsTests/Performance/ThroughputMeasurement.swift
+++ b/Tests/AsyncAlgorithmsTests/Performance/ThroughputMeasurement.swift
@@ -11,7 +11,7 @@
 
 import AsyncAlgorithms
 import Foundation
-import XCTest
+@preconcurrency import XCTest
 
 public struct InfiniteAsyncSequence<Value: Sendable>: AsyncSequence, Sendable {
   public typealias Element = Value

--- a/Tests/AsyncAlgorithmsTests/Support/ManualClock.swift
+++ b/Tests/AsyncAlgorithmsTests/Support/ManualClock.swift
@@ -9,8 +9,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import ClockStub
-
 public struct ManualClock: Clock {
   public struct Step: DurationProtocol {
     fileprivate var rawValue: Int

--- a/Tests/AsyncAlgorithmsTests/TestBufferedByteIterator.swift
+++ b/Tests/AsyncAlgorithmsTests/TestBufferedByteIterator.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
+@preconcurrency import XCTest
 import AsyncAlgorithms
 
 final class TestBufferedByteIterator: XCTestCase {

--- a/Tests/AsyncAlgorithmsTests/TestChain.swift
+++ b/Tests/AsyncAlgorithmsTests/TestChain.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
+@preconcurrency import XCTest
 import AsyncAlgorithms
 
 final class TestChain2: XCTestCase {

--- a/Tests/AsyncAlgorithmsTests/TestChannel.swift
+++ b/Tests/AsyncAlgorithmsTests/TestChannel.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
+@preconcurrency import XCTest
 import AsyncAlgorithms
 
 final class TestChannel: XCTestCase {

--- a/Tests/AsyncAlgorithmsTests/TestCombineLatest.swift
+++ b/Tests/AsyncAlgorithmsTests/TestCombineLatest.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
+@preconcurrency import XCTest
 import AsyncAlgorithms
 
 final class TestCombineLatest2: XCTestCase {

--- a/Tests/AsyncAlgorithmsTests/TestCompacted.swift
+++ b/Tests/AsyncAlgorithmsTests/TestCompacted.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
+@preconcurrency import XCTest
 import AsyncAlgorithms
 
 final class TestCompacted: XCTestCase {

--- a/Tests/AsyncAlgorithmsTests/TestInterspersed.swift
+++ b/Tests/AsyncAlgorithmsTests/TestInterspersed.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
+@preconcurrency import XCTest
 import AsyncAlgorithms
 
 final class TestInterspersed: XCTestCase {

--- a/Tests/AsyncAlgorithmsTests/TestJoin.swift
+++ b/Tests/AsyncAlgorithmsTests/TestJoin.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
+@preconcurrency import XCTest
 import AsyncAlgorithms
 
 extension Sequence where Element: Sequence, Element.Element: Equatable & Sendable {

--- a/Tests/AsyncAlgorithmsTests/TestLazy.swift
+++ b/Tests/AsyncAlgorithmsTests/TestLazy.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
+@preconcurrency import XCTest
 import AsyncAlgorithms
 
 final class TestLazy: XCTestCase {

--- a/Tests/AsyncAlgorithmsTests/TestManualClock.swift
+++ b/Tests/AsyncAlgorithmsTests/TestManualClock.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
+@preconcurrency import XCTest
 import AsyncAlgorithms
 
 final class TestManualClock: XCTestCase {

--- a/Tests/AsyncAlgorithmsTests/TestMerge.swift
+++ b/Tests/AsyncAlgorithmsTests/TestMerge.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
+@preconcurrency import XCTest
 import AsyncAlgorithms
 
 final class TestMerge2: XCTestCase {

--- a/Tests/AsyncAlgorithmsTests/TestReductions.swift
+++ b/Tests/AsyncAlgorithmsTests/TestReductions.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
+@preconcurrency import XCTest
 import AsyncAlgorithms
 
 final class TestReductions: XCTestCase {

--- a/Tests/AsyncAlgorithmsTests/TestTaskFirst.swift
+++ b/Tests/AsyncAlgorithmsTests/TestTaskFirst.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
+@preconcurrency import XCTest
 @testable import AsyncAlgorithms
 
 final class TestTaskFirst: XCTestCase {


### PR DESCRIPTION
Along with the newly minted sendability fixes for AsyncMapSequence et al this brings us down to 0 warnings again.