### PR TITLE
Clean up some more warnings via an additional Sendability pass audit

### DIFF
--- a/Sources/AsyncAlgorithms/AsyncBufferedByteIterator.swift
+++ b/Sources/AsyncAlgorithms/AsyncBufferedByteIterator.swift
@@ -67,17 +67,13 @@ public struct AsyncBufferedByteIterator: AsyncIteratorProtocol, Sendable {
 @frozen @usableFromInline
 internal struct _AsyncBytesBuffer: @unchecked Sendable {
   @usableFromInline
-  final class Storage {
-    fileprivate let readFunction: @Sendable (UnsafeMutableRawBufferPointer) async throws -> Int
+  final class Storage: Sendable {
     fileprivate let buffer: UnsafeMutableRawBufferPointer
-    fileprivate var finished = false
     
     init(
-      capacity: Int,
-      readFunction: @Sendable @escaping (UnsafeMutableRawBufferPointer) async throws -> Int
+      capacity: Int
     ) {
       precondition(capacity > 0)
-      self.readFunction = readFunction
       buffer = UnsafeMutableRawBufferPointer.allocate(
         byteCount: capacity,
         alignment: MemoryLayout<AnyObject>.alignment
@@ -93,11 +89,15 @@ internal struct _AsyncBytesBuffer: @unchecked Sendable {
   @usableFromInline internal var nextPointer: UnsafeRawPointer
   @usableFromInline internal var endPointer: UnsafeRawPointer
   
+  internal let readFunction: @Sendable (UnsafeMutableRawBufferPointer) async throws -> Int
+  internal var finished = false
+  
   @usableFromInline init(
     capacity: Int,
     readFunction: @Sendable @escaping (UnsafeMutableRawBufferPointer) async throws -> Int
   ) {
-    let s = Storage(capacity: capacity, readFunction: readFunction)
+    let s = Storage(capacity: capacity)
+    self.readFunction = readFunction
     storage = s
     nextPointer = UnsafeRawPointer(s.buffer.baseAddress!)
     endPointer = nextPointer
@@ -105,21 +105,21 @@ internal struct _AsyncBytesBuffer: @unchecked Sendable {
   
   @inline(never) @usableFromInline
   internal mutating func reloadBufferAndNext() async throws -> UInt8? {
-    if storage.finished {
+    if finished {
       return nil
     }
     try Task.checkCancellation()
     do {
-      let readSize: Int = try await storage.readFunction(storage.buffer)
+      let readSize: Int = try await readFunction(storage.buffer)
       if readSize == 0 {
-        storage.finished = true
+        finished = true
         nextPointer = endPointer
         return nil
       }
       nextPointer = UnsafeRawPointer(storage.buffer.baseAddress!)
       endPointer = nextPointer + readSize
     } catch {
-      storage.finished = true
+      finished = true
       nextPointer = endPointer
       throw error
     }

--- a/Sources/AsyncAlgorithms/AsyncCombineLatest3Sequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncCombineLatest3Sequence.swift
@@ -13,7 +13,7 @@ public func combineLatest<Base1: AsyncSequence, Base2: AsyncSequence, Base3: Asy
   AsyncCombineLatest3Sequence(base1, base2, base3)
 }
 
-public struct AsyncCombineLatest3Sequence<Base1: AsyncSequence, Base2: AsyncSequence, Base3: AsyncSequence>
+public struct AsyncCombineLatest3Sequence<Base1: AsyncSequence, Base2: AsyncSequence, Base3: AsyncSequence>: Sendable
   where
     Base1: Sendable, Base2: Sendable, Base3: Sendable,
     Base1.Element: Sendable, Base2.Element: Sendable, Base3.Element: Sendable,
@@ -32,7 +32,7 @@ public struct AsyncCombineLatest3Sequence<Base1: AsyncSequence, Base2: AsyncSequ
 extension AsyncCombineLatest3Sequence: AsyncSequence {
   public typealias Element = (Base1.Element, Base2.Element, Base3.Element)
   
-  public struct Iterator: AsyncIteratorProtocol {
+  public struct Iterator: AsyncIteratorProtocol, Sendable {
     var iterator: AsyncCombineLatest2Sequence<AsyncCombineLatest2Sequence<Base1, Base2>, Base3>.Iterator
     
     init(_ base1: Base1.AsyncIterator, _ base2: Base2.AsyncIterator, _ base3: Base3.AsyncIterator) {

--- a/Sources/AsyncSequenceValidation/Expectation.swift
+++ b/Sources/AsyncSequenceValidation/Expectation.swift
@@ -10,13 +10,13 @@
 //===----------------------------------------------------------------------===//
 
 extension AsyncSequenceValidationDiagram {
-  public struct ExpectationResult {
+  public struct ExpectationResult: Sendable {
     public var expected: [(Clock.Instant, Result<String?, Error>)]
     public var actual: [(Clock.Instant, Result<String?, Error>)]
   }
   
-  public struct ExpectationFailure: CustomStringConvertible {
-    public enum Kind {
+  public struct ExpectationFailure: Sendable, CustomStringConvertible {
+    public enum Kind: Sendable {
       case expectedFinishButGotValue(String)
       case expectedMismatch(String, String)
       case expectedValueButGotFinished(String)

--- a/Sources/AsyncSequenceValidation/Input.swift
+++ b/Sources/AsyncSequenceValidation/Input.swift
@@ -21,7 +21,7 @@ extension AsyncSequenceValidationDiagram {
     let queue: WorkQueue
     let index: Int
     
-    public struct Iterator: AsyncIteratorProtocol {
+    public struct Iterator: AsyncIteratorProtocol, Sendable {
       let state: ManagedCriticalState<State>
       let queue: WorkQueue
       let index: Int

--- a/Sources/AsyncSequenceValidation/Theme.swift
+++ b/Sources/AsyncSequenceValidation/Theme.swift
@@ -20,7 +20,7 @@ extension AsyncSequenceValidationTheme where Self == AsyncSequenceValidationDiag
 }
 
 extension AsyncSequenceValidationDiagram {
-  public enum Token {
+  public enum Token: Sendable {
     case step
     case error
     case finish
@@ -33,7 +33,7 @@ extension AsyncSequenceValidationDiagram {
     case value(String)
   }
   
-  public struct ASCIITheme: AsyncSequenceValidationTheme {
+  public struct ASCIITheme: AsyncSequenceValidationTheme, Sendable {
     public func token(_ character: Character, inValue: Bool) -> AsyncSequenceValidationDiagram.Token {
       switch character {
       case "-": return .step

--- a/Tests/AsyncAlgorithmsTests/TestValidator.swift
+++ b/Tests/AsyncAlgorithmsTests/TestValidator.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
+@preconcurrency import XCTest
 import AsyncAlgorithms
 
 final class TestValidator: XCTestCase {


### PR DESCRIPTION
This brings our swift 6 mode warning count down to 2 spots (which are perhaps unavoidable).