### PR TITLE
Add delayNext “,” operator to validation diagram

### DIFF
--- a/Guides/Validation.md
+++ b/Guides/Validation.md
@@ -47,6 +47,7 @@ The syntax is trivially parsable (and consequently customizable). By default, th
 |   `[`   | Begin group       | `"[ab]-"`  |
 |   `]`   | End group         | `"[ab]-"`  |
 |   `'`   | Begin/End Value   | `"'foo'-"` |
+|   `,`   | Delay next        | `",[a,]b"` |
 
 Because some events may take up more than one character and the alignment is important to the visual progression of events, spaces are not counted as part of the parsed events. A space means that no time is advanced and not event is produced or expected. This means that the string `"a -    -b- -"` is equivalent to `"a--b--"`.
 
@@ -59,6 +60,9 @@ struct EmojiTokens: AsyncSequenceValidationTheme {
     case "➖": return .step
     case "❗️": return .error
     case "❌": return .finish
+    case "➡️": return .beginValue
+    case "⬅️": return .endValue
+    case "⏳": return .delayNext
     case " ": return .skip
     default: return .value(String(character))
     }
@@ -214,6 +218,7 @@ Access to the validation diagram input list is done through calls such as `$0.in
 |   `[`   | `.beginGroup`             | Begin group       | `"[ab]-"`  |
 |   `]`   | `.endGroup`               | End group         | `"[ab]-"`  |
 |   `'`   | `.beginValue` `.endValue` | Begin/End Value   | `"'foo'-"` |
+|   `,`   | `.delayNext`              | Delay next        | `",[a,]b"` |
 |   ` `   | `.skip`                   | Skip/Ignore       | `"a b- |"` |
 |         | `.value`                  | Values.           | `"ab-|"`   |
 
@@ -234,6 +239,7 @@ extension AsyncSequenceValidationDiagram {
     case error
     case finish
     case cancel
+    case delayNext
     case beginValue
     case endValue
     case beginGroup

--- a/Sources/AsyncSequenceValidation/Event.swift
+++ b/Sources/AsyncSequenceValidation/Event.swift
@@ -33,6 +33,7 @@ extension AsyncSequenceValidationDiagram {
     case value(String, String.Index)
     case failure(Error, String.Index)
     case finish(String.Index)
+    case delayNext(String.Index)
     case cancel(String.Index)
     
     var results: [Result<String?, Error>] {
@@ -40,6 +41,7 @@ extension AsyncSequenceValidationDiagram {
       case .value(let value, _): return [.success(value)]
       case .failure(let failure, _): return [.failure(failure)]
       case .finish: return [.success(nil)]
+      case .delayNext: return []
       case .cancel: return []
       }
     }
@@ -49,6 +51,7 @@ extension AsyncSequenceValidationDiagram {
       case .value(_, let index): return index
       case .failure(_, let index): return index
       case .finish(let index): return index
+      case .delayNext(let index): return index
       case .cancel(let index): return index
       }
     }
@@ -96,6 +99,15 @@ extension AsyncSequenceValidationDiagram {
               when = when.advanced(by: .steps(1))
             }
             emissions.append((when, .cancel(index)))
+          } else {
+            string?.append(ch)
+          }
+        case .delayNext:
+          if string == nil {
+            if grouping == 0 {
+              when = when.advanced(by: .steps(1))
+            }
+            emissions.append((when, .delayNext(index)))
           } else {
             string?.append(ch)
           }

--- a/Sources/AsyncSequenceValidation/Theme.swift
+++ b/Sources/AsyncSequenceValidation/Theme.swift
@@ -25,6 +25,7 @@ extension AsyncSequenceValidationDiagram {
     case error
     case finish
     case cancel
+    case delayNext
     case beginValue
     case endValue
     case beginGroup
@@ -40,6 +41,7 @@ extension AsyncSequenceValidationDiagram {
       case "^": return .error
       case "|": return .finish
       case ";": return .cancel
+      case ",": return .delayNext
       case "'": return inValue ? .endValue : .beginValue
       case "[": return .beginGroup
       case "]": return .endGroup


### PR DESCRIPTION
Normally, the validation diagram eagerly calls `next()` on the sequence at its earliest opportunity. For testing some sequences, you need control over when `next()` gets called. The "delay next" operator (`,`) will delay the subsequent call to `next()` until the tick after it.

This will be very useful in testing sequences like `buffer`, and others for which the timing of the `next()` call influences the results and/or timing of the elements obtained from the sequence.