### PR TITLE
Add a label for consistency with AsyncThrowingChannel for the element type of AsyncChannel

### DIFF
--- a/Sources/AsyncAlgorithms/AsyncChannel.swift
+++ b/Sources/AsyncAlgorithms/AsyncChannel.swift
@@ -86,7 +86,7 @@ public final class AsyncChannel<Element: Sendable>: AsyncSequence, Sendable {
   
   let state = ManagedCriticalState(State())
   
-  public init(_ elementType: Element.Type = Element.self) { }
+  public init(element elementType: Element.Type = Element.self) { }
   
   func establish() -> Int {
     state.withCriticalRegion { state in


### PR DESCRIPTION
AsyncThrowingChannel labeled both the element and the failure, this makes AsyncChannel label its element for consistency.