### PR TITLE
Print diagnostics such that the comparisons of expected versus actual use the diagram as would be written

### DIFF
--- a/Sources/AsyncSequenceValidation/AsyncSequenceValidationDiagram.swift
+++ b/Sources/AsyncSequenceValidation/AsyncSequenceValidationDiagram.swift
@@ -46,6 +46,17 @@ public struct AsyncSequenceValidationDiagram : Sendable {
   ) -> some AsyncSequenceValidationTest where Operation.Element == String {
     Test(inputs: [input1, input2, input3], sequence: sequence, output: output)
   }
+
+  public static func buildBlock<Operation: AsyncSequence>(
+    _ input1: String,
+    _ input2: String,
+    _ input3: String,
+    _ input4: String,
+    _ sequence: Operation,
+    _ output: String
+  ) -> some AsyncSequenceValidationTest where Operation.Element == String {
+    Test(inputs: [input1, input2, input3, input4], sequence: sequence, output: output)
+  }
   
   let queue: WorkQueue
   

--- a/Sources/AsyncSequenceValidation/Expectation.swift
+++ b/Sources/AsyncSequenceValidation/Expectation.swift
@@ -13,6 +13,77 @@ extension AsyncSequenceValidationDiagram {
   public struct ExpectationResult {
     public var expected: [(Clock.Instant, Result<String?, Error>)]
     public var actual: [(Clock.Instant, Result<String?, Error>)]
+    
+    func reconstitute<Theme: AsyncSequenceValidationTheme>(_ result: Result<String?, Error>, theme: Theme) -> String {
+      var reconstituted = ""
+      switch result {
+      case .success(let value):
+        if let value = value {
+          if value.count > 1 {
+            reconstituted += theme.description(for: .beginValue)
+            reconstituted += theme.description(for: .value(value))
+            reconstituted += theme.description(for: .endValue)
+          } else {
+            reconstituted += theme.description(for: .value(value))
+          }
+        } else {
+          reconstituted += theme.description(for: .finish)
+        }
+      case .failure:
+        reconstituted += theme.description(for: .error)
+      }
+      return reconstituted
+    }
+    
+    func reconstitute<Theme: AsyncSequenceValidationTheme>(_ events: [Clock.Instant : [Result<String?, Error>]], theme: Theme, end: Clock.Instant) -> String {
+      var now = Clock.Instant(when: .zero)
+      var reconstituted = ""
+      while now <= end {
+        if let results = events[now] {
+          if results.count == 1 {
+            reconstituted += reconstitute(results[0], theme: theme)
+          } else {
+            reconstituted += theme.description(for: .beginGroup)
+            for result in results {
+              reconstituted += reconstitute(result, theme: theme)
+            }
+            reconstituted += theme.description(for: .endGroup)
+          }
+        } else {
+          reconstituted += theme.description(for: .step)
+        }
+        now = now.advanced(by: .steps(1))
+      }
+      return reconstituted
+    }
+    
+    public func reconstituteExpected<Theme: AsyncSequenceValidationTheme>(theme: Theme) -> String {
+      var events = [Clock.Instant : [Result<String?, Error>]]()
+      var end: Clock.Instant = Clock.Instant(when: .zero)
+      
+      for (when, result) in expected {
+        events[when, default: []].append(result)
+        if when > end {
+          end = when
+        }
+      }
+      
+      return reconstitute(events, theme: theme, end: end)
+    }
+    
+    public func reconstituteActual<Theme: AsyncSequenceValidationTheme>(theme: Theme) -> String {
+      var events = [Clock.Instant : [Result<String?, Error>]]()
+      var end: Clock.Instant = Clock.Instant(when: .zero)
+      
+      for (when, result) in actual {
+        events[when, default: []].append(result)
+        if when > end {
+          end = when
+        }
+      }
+      
+      return reconstitute(events, theme: theme, end: end)
+    }
   }
   
   public struct ExpectationFailure: CustomStringConvertible {

--- a/Sources/AsyncSequenceValidation/Test.swift
+++ b/Sources/AsyncSequenceValidation/Test.swift
@@ -229,11 +229,15 @@ extension AsyncSequenceValidationDiagram {
   
   public static func test<Test: AsyncSequenceValidationTest, Theme: AsyncSequenceValidationTheme>(
     theme: Theme,
-    @AsyncSequenceValidationDiagram _ build: (inout AsyncSequenceValidationDiagram) -> Test
+    @AsyncSequenceValidationDiagram _ build: (AsyncSequenceValidationDiagram) -> Test
   ) throws -> (ExpectationResult, [ExpectationFailure]) {
-    var diagram = AsyncSequenceValidationDiagram()
+    let diagram = AsyncSequenceValidationDiagram()
     let clock = diagram.clock
-    let test = build(&diagram)
+    let test = build(diagram)
+    for index in 0..<test.inputs.count {
+      // fault in all inputs
+      _ = diagram.inputs[index]
+    }
     
     for (index, input) in diagram.inputs.enumerated() {
       try input.parse(test.inputs[index], theme: theme)
@@ -327,7 +331,7 @@ extension AsyncSequenceValidationDiagram {
   }
   
   public static func test<Test: AsyncSequenceValidationTest>(
-    @AsyncSequenceValidationDiagram _ build: (inout AsyncSequenceValidationDiagram) -> Test
+    @AsyncSequenceValidationDiagram _ build: (AsyncSequenceValidationDiagram) -> Test
   ) throws -> (ExpectationResult, [ExpectationFailure]) {
     try self.test(theme: .ascii, build)
   }

--- a/Sources/AsyncSequenceValidation/Theme.swift
+++ b/Sources/AsyncSequenceValidation/Theme.swift
@@ -11,6 +11,8 @@
 
 public protocol AsyncSequenceValidationTheme {
   func token(_ character: Character, inValue: Bool) -> AsyncSequenceValidationDiagram.Token
+  
+  func description(for token: AsyncSequenceValidationDiagram.Token) -> String
 }
 
 extension AsyncSequenceValidationTheme where Self == AsyncSequenceValidationDiagram.ASCIITheme {
@@ -47,6 +49,22 @@ extension AsyncSequenceValidationDiagram {
       case "]": return .endGroup
       case " ": return .skip
       default: return .value(String(character))
+      }
+    }
+    
+    public func description(for token: AsyncSequenceValidationDiagram.Token) -> String {
+      switch token {
+      case .step: return "-"
+      case .error: return "^"
+      case .finish: return "|"
+      case .cancel: return ";"
+      case .delayNext: return ","
+      case .beginValue: return "'"
+      case .endValue: return "'"
+      case .beginGroup: return "["
+      case .endGroup: return "]"
+      case .skip: return " "
+      case .value(let value): return value
       }
     }
   }

--- a/Tests/AsyncAlgorithmsTests/Support/ValidationTest.swift
+++ b/Tests/AsyncAlgorithmsTests/Support/ValidationTest.swift
@@ -14,20 +14,16 @@ import AsyncAlgorithms
 import AsyncSequenceValidation
 
 extension XCTestCase {
-  public func validate<Test: AsyncSequenceValidationTest, Theme: AsyncSequenceValidationTheme>(theme: Theme, @AsyncSequenceValidationDiagram _ build: (inout AsyncSequenceValidationDiagram) -> Test, file: StaticString = #file, line: UInt = #line) {
+  public func validate<Test: AsyncSequenceValidationTest, Theme: AsyncSequenceValidationTheme>(theme: Theme, @AsyncSequenceValidationDiagram _ build: (AsyncSequenceValidationDiagram) -> Test, file: StaticString = #file, line: UInt = #line) {
     let location = XCTSourceCodeLocation(filePath: file.description, lineNumber: Int(line))
     let context = XCTSourceCodeContext(location: location)
     do {
       let (result, failures) = try AsyncSequenceValidationDiagram.test(theme: theme, build)
       if failures.count > 0 {
         print("Expected")
-        for (when, result) in result.expected {
-          print(when, result)
-        }
+        print(result.reconstituteExpected(theme: theme))
         print("Actual")
-        for (when, result) in result.actual {
-          print(when, result)
-        }
+        print(result.reconstituteActual(theme: theme))
       }
       for failure in failures {
         let issue = XCTIssue(type: .assertionFailure, compactDescription: failure.description, detailedDescription: nil, sourceCodeContext: context, associatedError: nil, attachments: [])
@@ -39,7 +35,7 @@ extension XCTestCase {
     }
   }
   
-  public func validate<Test: AsyncSequenceValidationTest>(@AsyncSequenceValidationDiagram _ build: (inout AsyncSequenceValidationDiagram) -> Test, file: StaticString = #file, line: UInt = #line) {
+  public func validate<Test: AsyncSequenceValidationTest>(@AsyncSequenceValidationDiagram _ build: (AsyncSequenceValidationDiagram) -> Test, file: StaticString = #file, line: UInt = #line) {
     validate(theme: .ascii, build, file: file, line: line)
   }
 }

--- a/Tests/AsyncAlgorithmsTests/TestValidationTests.swift
+++ b/Tests/AsyncAlgorithmsTests/TestValidationTests.swift
@@ -84,6 +84,22 @@ final class TestValidationDiagram: XCTestCase {
         default: return .value(String(character))
         }
       }
+      
+      func description(for token: AsyncSequenceValidationDiagram.Token) -> String {
+        switch token {
+        case .step: return "➖"
+        case .error: return "❗️"
+        case .finish: return "❌"
+        case .cancel: return ""
+        case .delayNext: return "⏳"
+        case .beginValue: return "➡️"
+        case .endValue: return "⬅️"
+        case .beginGroup: return ""
+        case .endGroup: return ""
+        case .skip: return " "
+        case .value(let value): return value
+        }
+      }
     }
     
     validate(theme: EmojiTokens()) {


### PR DESCRIPTION
This means that the printed failure is copy/paste-able to the actual test.

e.g.

```
    validate {
      "a--b--^"
      $0.inputs[0].map { item in await Task { item.capitalized }.value }
      "A--B--C|"
    }
```

prints the following

```
Expected
-A--B--C|
Actual
-A--B--^
TestValidationTests.swift:180: Expected failure in -[AsyncAlgorithmsTests.TestValidationDiagram test_diagram_failure_error_for_value]: expected "C" but got failure at tick 6
TestValidationTests.swift:180: Expected failure in -[AsyncAlgorithmsTests.TestValidationDiagram test_diagram_failure_error_for_value]: expected finish at tick 7
```