### PR TITLE
Rename tests for Task.select and remove the testable import to enable release mode testing

### DIFF
--- a/Tests/AsyncAlgorithmsTests/TestTaskSelect.swift
+++ b/Tests/AsyncAlgorithmsTests/TestTaskSelect.swift
@@ -10,9 +10,9 @@
 //===----------------------------------------------------------------------===//
 
 @preconcurrency import XCTest
-@testable import AsyncAlgorithms
+import AsyncAlgorithms
 
-final class TestTaskFirst: XCTestCase {
+final class TestTaskSelect: XCTestCase {
   func test_first() async {
     let firstValue = await Task.select(Task {
       return 1


### PR DESCRIPTION
The `@testable import` was preventing us from testing in release mode. It wasn't needed anymore so remove it (and drive by rename of the tests for `Task.select` since it is no longer called `Task.first`)