### PR TITLE
Resolve a race condition that caused repeated testing of channel cancellation to sometimes hang

### DIFF
--- a/Sources/AsyncAlgorithms/AsyncChannel.swift
+++ b/Sources/AsyncAlgorithms/AsyncChannel.swift
@@ -75,7 +75,7 @@ public final class AsyncChannel<Element: Sendable>: AsyncSequence, Sendable {
     case pending([UnsafeContinuation<UnsafeContinuation<Element?, Never>?, Never>])
     case awaiting(Set<Awaiting>)
     
-    mutating func remove(_ generation: Int) -> UnsafeContinuation<Element?, Never>? {
+    mutating func cancel(_ generation: Int) -> UnsafeContinuation<Element?, Never>? {
       switch self {
       case .awaiting(var awaiting):
         let continuation = awaiting.remove(Awaiting(placeholder: generation))?.continuation
@@ -109,7 +109,7 @@ public final class AsyncChannel<Element: Sendable>: AsyncSequence, Sendable {
   
   func cancel(_ generation: Int) {
     state.withCriticalRegion { state in
-      state.emission.remove(generation)
+      state.emission.cancel(generation)
     }?.resume(returning: nil)
   }
   

--- a/Sources/AsyncAlgorithms/AsyncThrowingChannel.swift
+++ b/Sources/AsyncAlgorithms/AsyncThrowingChannel.swift
@@ -80,7 +80,7 @@ public final class AsyncThrowingChannel<Element: Sendable, Failure: Error>: Asyn
     case pending([UnsafeContinuation<UnsafeContinuation<Element?, Error>?, Never>])
     case awaiting(Set<Awaiting>)
     
-    mutating func remove(_ generation: Int) -> UnsafeContinuation<Element?, Error>? {
+    mutating func cancel(_ generation: Int) -> UnsafeContinuation<Element?, Error>? {
       switch self {
       case .awaiting(var awaiting):
         let continuation = awaiting.remove(Awaiting(placeholder: generation))?.continuation
@@ -114,7 +114,7 @@ public final class AsyncThrowingChannel<Element: Sendable, Failure: Error>: Asyn
   
   func cancel(_ generation: Int) {
     state.withCriticalRegion { state in
-      state.emission.remove(generation)
+      state.emission.cancel(generation)
     }?.resume(returning: nil)
   }
   


### PR DESCRIPTION
The race that could occur is that the cancellation signal can cooperatively hit while the emission state was idle and not yet awaiting. This would mean that the continuation for that emission would just hang around never being satisfied. This puts a placeholder there for that cancellation to be properly resumed when detected that the side is cancelled.