### PR TITLE
Restore availability and mark everything as 9999 to match stdlib availability for 5.7 for now

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,18 +20,12 @@ let package = Package(
   dependencies: [],
   targets: [
     .target(
-      name: "AsyncAlgorithms",
-      swiftSettings: [
-        .unsafeFlags([
-          "-Xfrontend", "-disable-availability-checking"
-        ])
-      ]),
+      name: "AsyncAlgorithms"),
     .target(
       name: "AsyncSequenceValidation",
       dependencies: ["_CAsyncSequenceValidationSupport"],
       swiftSettings: [
         .unsafeFlags([
-          "-Xfrontend", "-disable-availability-checking",
           "-Xfrontend", "-enable-experimental-pairwise-build-block"
         ])
       ]),

--- a/Sources/AsyncAlgorithms/AsyncChunksOfCountOrSignalSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncChunksOfCountOrSignalSequence.swift
@@ -26,18 +26,22 @@ extension AsyncSequence {
     chunked(by: signal, into: [Element].self)
   }
 
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public func chunks<C: Clock, Collected: RangeReplaceableCollection>(ofCount count: Int, or timer: AsyncTimerSequence<C>, into: Collected.Type) -> AsyncChunksOfCountOrSignalSequence<Self, Collected, AsyncTimerSequence<C>> where Collected.Element == Element {
     AsyncChunksOfCountOrSignalSequence(self, count: count, signal: timer)
   }
 
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public func chunks<C: Clock>(ofCount count: Int, or timer: AsyncTimerSequence<C>) -> AsyncChunksOfCountOrSignalSequence<Self, [Element], AsyncTimerSequence<C>> {
     chunks(ofCount: count, or: timer, into: [Element].self)
   }
 
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public func chunked<C: Clock, Collected: RangeReplaceableCollection>(by timer: AsyncTimerSequence<C>, into: Collected.Type) -> AsyncChunksOfCountOrSignalSequence<Self, Collected, AsyncTimerSequence<C>> where Collected.Element == Element {
     AsyncChunksOfCountOrSignalSequence(self, count: nil, signal: timer)
   }
 
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public func chunked<C: Clock>(by timer: AsyncTimerSequence<C>) -> AsyncChunksOfCountOrSignalSequence<Self, [Element], AsyncTimerSequence<C>> {
     chunked(by: timer, into: [Element].self)
   }

--- a/Sources/AsyncAlgorithms/AsyncDebounceSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncDebounceSequence.swift
@@ -10,15 +10,18 @@
 //===----------------------------------------------------------------------===//
 
 extension AsyncSequence {
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public func debounce<C: Clock>(for interval: C.Instant.Duration, tolerance: C.Instant.Duration? = nil, clock: C) -> AsyncDebounceSequence<Self, C> {
     AsyncDebounceSequence(self, interval: interval, tolerance: tolerance, clock: clock)
   }
   
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public func debounce(for interval: Duration, tolerance: Duration? = nil) -> AsyncDebounceSequence<Self, ContinuousClock> {
     debounce(for: interval, tolerance: tolerance, clock: .continuous)
   }
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 public struct AsyncDebounceSequence<Base: AsyncSequence, C: Clock>: Sendable
   where Base.AsyncIterator: Sendable, Base.Element: Sendable, Base: Sendable {
   let base: Base
@@ -34,6 +37,7 @@ public struct AsyncDebounceSequence<Base: AsyncSequence, C: Clock>: Sendable
   }
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 extension AsyncDebounceSequence: AsyncSequence {
   public typealias Element = Base.Element
   

--- a/Sources/AsyncAlgorithms/AsyncThrottleSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncThrottleSequence.swift
@@ -10,14 +10,17 @@
 //===----------------------------------------------------------------------===//
 
 extension AsyncSequence {
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public func throttle<C: Clock, Reduced>(for interval: C.Instant.Duration, clock: C, reducing: @Sendable @escaping (Reduced?, Element) async -> Reduced) -> AsyncThrottleSequence<Self, C, Reduced> {
     AsyncThrottleSequence(self, interval: interval, clock: clock, reducing: reducing)
   }
   
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public func throttle<Reduced>(for interval: Duration, reducing: @Sendable @escaping (Reduced?, Element) async -> Reduced) -> AsyncThrottleSequence<Self, ContinuousClock, Reduced> {
     throttle(for: interval, clock: .continuous, reducing: reducing)
   }
   
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public func throttle<C: Clock>(for interval: C.Instant.Duration, clock: C, latest: Bool = true) -> AsyncThrottleSequence<Self, C, Element> {
     throttle(for: interval, clock: clock) { previous, element in
       if latest {
@@ -28,11 +31,13 @@ extension AsyncSequence {
     }
   }
   
+  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
   public func throttle(for interval: Duration, latest: Bool = true) -> AsyncThrottleSequence<Self, ContinuousClock, Element> {
     throttle(for: interval, clock: .continuous, latest: latest)
   }
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 public struct AsyncThrottleSequence<Base: AsyncSequence, C: Clock, Reduced> {
   let base: Base
   let interval: C.Instant.Duration
@@ -47,6 +52,7 @@ public struct AsyncThrottleSequence<Base: AsyncSequence, C: Clock, Reduced> {
   }
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 extension AsyncThrottleSequence: AsyncSequence {
   public typealias Element = Reduced
   
@@ -85,5 +91,8 @@ extension AsyncThrottleSequence: AsyncSequence {
   }
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 extension AsyncThrottleSequence: Sendable where Base: Sendable, Element: Sendable { }
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 extension AsyncThrottleSequence.Iterator: Sendable where Base.AsyncIterator: Sendable { }

--- a/Sources/AsyncAlgorithms/AsyncTimerSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncTimerSequence.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 public struct AsyncTimerSequence<C: Clock>: AsyncSequence {
   public typealias Element = C.Instant
   
@@ -67,18 +68,22 @@ public struct AsyncTimerSequence<C: Clock>: AsyncSequence {
   }
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 extension AsyncTimerSequence {
   public static func repeating(every interval: C.Instant.Duration, tolerance: C.Instant.Duration? = nil, clock: C) -> AsyncTimerSequence<C> {
     return AsyncTimerSequence(interval: interval, tolerance: tolerance, clock: clock)
   }
 }
 
-
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 extension AsyncTimerSequence where C == SuspendingClock {
   public static func repeating(every interval: Duration, tolerance: Duration? = nil) -> AsyncTimerSequence<SuspendingClock> {
     return AsyncTimerSequence(interval: interval, tolerance: tolerance, clock: SuspendingClock())
   }
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 extension AsyncTimerSequence: Sendable { }
+
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 extension AsyncTimerSequence.Iterator: Sendable { }

--- a/Sources/AsyncSequenceValidation/AsyncSequenceValidationDiagram.swift
+++ b/Sources/AsyncSequenceValidation/AsyncSequenceValidationDiagram.swift
@@ -11,6 +11,7 @@
 
 import _CAsyncSequenceValidationSupport
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 @resultBuilder
 public struct AsyncSequenceValidationDiagram : Sendable {
   public struct Component<T> {

--- a/Sources/AsyncSequenceValidation/Clock.swift
+++ b/Sources/AsyncSequenceValidation/Clock.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 extension AsyncSequenceValidationDiagram {
   public struct Clock {
     let queue: WorkQueue
@@ -19,6 +20,7 @@ extension AsyncSequenceValidationDiagram {
   }
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 extension AsyncSequenceValidationDiagram.Clock: Clock {
   public struct Step: DurationProtocol, Hashable, CustomStringConvertible {
     internal var rawValue: Int

--- a/Sources/AsyncSequenceValidation/Event.swift
+++ b/Sources/AsyncSequenceValidation/Event.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 extension AsyncSequenceValidationDiagram {
   struct Failure: Error, Equatable { }
   

--- a/Sources/AsyncSequenceValidation/Expectation.swift
+++ b/Sources/AsyncSequenceValidation/Expectation.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 extension AsyncSequenceValidationDiagram {
   public struct ExpectationResult: Sendable {
     public struct Event: Sendable {

--- a/Sources/AsyncSequenceValidation/Input.swift
+++ b/Sources/AsyncSequenceValidation/Input.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 extension AsyncSequenceValidationDiagram {
   public struct Specification: Sendable {
     public let specification: String

--- a/Sources/AsyncSequenceValidation/Job.swift
+++ b/Sources/AsyncSequenceValidation/Job.swift
@@ -11,6 +11,7 @@
 
 import _CAsyncSequenceValidationSupport
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 struct Job: Hashable, @unchecked Sendable {
   let job: JobRef
   

--- a/Sources/AsyncSequenceValidation/TaskDriver.swift
+++ b/Sources/AsyncSequenceValidation/TaskDriver.swift
@@ -19,11 +19,13 @@ import _CAsyncSequenceValidationSupport
 #error("TODO: Port TaskDriver threading to windows")
 #endif
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 func start_thread(_ raw: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer? {
   Unmanaged<TaskDriver>.fromOpaque(raw).takeRetainedValue().run()
   return nil
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 final class TaskDriver {
   let work: (TaskDriver) -> Void
   let queue: WorkQueue

--- a/Sources/AsyncSequenceValidation/Test.swift
+++ b/Sources/AsyncSequenceValidation/Test.swift
@@ -18,6 +18,7 @@ internal func _swiftJobRun(
   _ executor: UnownedSerialExecutor
 ) -> ()
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 public protocol AsyncSequenceValidationTest: Sendable {
   var inputs: [AsyncSequenceValidationDiagram.Specification] { get }
   var output: AsyncSequenceValidationDiagram.Specification { get }
@@ -25,6 +26,7 @@ public protocol AsyncSequenceValidationTest: Sendable {
   func test<C: Clock>(with clock: C, activeTicks: [C.Instant], output: AsyncSequenceValidationDiagram.Specification, _ event: (String) -> Void) async throws
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 extension AsyncSequenceValidationDiagram {
   struct Test<Operation: AsyncSequence>: AsyncSequenceValidationTest, @unchecked Sendable where Operation.Element == String {
     let inputs: [Specification]

--- a/Sources/AsyncSequenceValidation/Theme.swift
+++ b/Sources/AsyncSequenceValidation/Theme.swift
@@ -9,18 +9,21 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 public protocol AsyncSequenceValidationTheme {
   func token(_ character: Character, inValue: Bool) -> AsyncSequenceValidationDiagram.Token
   
   func description(for token: AsyncSequenceValidationDiagram.Token) -> String
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 extension AsyncSequenceValidationTheme where Self == AsyncSequenceValidationDiagram.ASCIITheme {
   public static var ascii: AsyncSequenceValidationDiagram.ASCIITheme {
     return AsyncSequenceValidationDiagram.ASCIITheme()
   }
 }
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 extension AsyncSequenceValidationDiagram {
   public enum Token: Sendable {
     case step

--- a/Sources/AsyncSequenceValidation/WorkQueue.swift
+++ b/Sources/AsyncSequenceValidation/WorkQueue.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, *)
 struct WorkQueue: Sendable {
   enum Item: CustomStringConvertible, Comparable {
     case blocked(Token, AsyncSequenceValidationDiagram.Clock.Instant, UnsafeContinuation<Void, Error>)


### PR DESCRIPTION
The standard library marks availability of `Clock` et al as swift 5.7 - this means only our tests need to disable availability guards and the base implementation can have placeholder markers until the 5.7 availability is resident.