### PR TITLE
Only print expected/actual in Xcode

### DIFF
--- a/Tests/AsyncAlgorithmsTests/Support/ValidationTest.swift
+++ b/Tests/AsyncAlgorithmsTests/Support/ValidationTest.swift
@@ -27,10 +27,13 @@ extension XCTestCase {
         Actual
         \(result.reconstituteActual(theme: theme))
         """
-        print("Expected")
-        print(result.reconstituteExpected(theme: theme))
-        print("Actual")
-        print(result.reconstituteActual(theme: theme))
+        // only show expected/actual when running in Xcode
+        if ProcessInfo.processInfo.environment["XCTestSessionIdentifier"] != nil {
+          print("Expected")
+          print(result.reconstituteExpected(theme: theme))
+          print("Actual")
+          print(result.reconstituteActual(theme: theme))
+        }
       }
       for failure in failures {
         if let specification = failure.specification {


### PR DESCRIPTION
This makes it such that only Xcode gets the print statements for test mismatch on output. `swift test` ends up buffering all that output to the end because the tests are run in parallel yet still keeps the diagnostics with Xcode.