### PR TITLE
Reduce warnings for preconcurrency and non mutated vars

### DIFF
--- a/Sources/AsyncAlgorithms/AsyncBufferSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncBufferSequence.swift
@@ -78,7 +78,7 @@ actor AsyncBufferState<Input: Sendable, Output: Sendable> {
 
   func terminate() {
     terminationState = .terminal
-    var oldPending = pending
+    let oldPending = pending
     pending = []
     for continuation in oldPending {
       continuation.resume(returning: .success(nil))

--- a/Tests/AsyncAlgorithmsTests/TestBuffer.swift
+++ b/Tests/AsyncAlgorithmsTests/TestBuffer.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
+@preconcurrency import XCTest
 import AsyncAlgorithms
 
 final class TestBuffer: XCTestCase {

--- a/Tests/AsyncAlgorithmsTests/TestRemoveDuplicates.swift
+++ b/Tests/AsyncAlgorithmsTests/TestRemoveDuplicates.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
+@preconcurrency import XCTest
 import AsyncAlgorithms
 
 final class TestRemoveDuplicates: XCTestCase {
@@ -64,7 +64,7 @@ final class TestRemoveDuplicates: XCTestCase {
         throw NSError(domain: NSCocoaErrorDomain, code: -1, userInfo: nil)
       }
       return $0
-    } as (Int) throws -> Int)
+    } as @Sendable (Int) throws -> Int)
 
     do {
       for try await item in throwingSequence.removeDuplicates() {

--- a/Tests/AsyncAlgorithmsTests/TestZip.swift
+++ b/Tests/AsyncAlgorithmsTests/TestZip.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
+@preconcurrency import XCTest
 import AsyncAlgorithms
 
 final class TestZip2: XCTestCase {


### PR DESCRIPTION
This resolves warnings down to 0 again.