### PR TITLE
Add support for rendering docc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
 .swiftpm
+Package.resolved

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,9 @@ let package = Package(
     .library(name: "AsyncSequenceValidation", targets: ["AsyncSequenceValidation"]),
     .library(name: "_CAsyncSequenceValidationSupport", type: .static, targets: ["AsyncSequenceValidation"])
   ],
-  dependencies: [],
+  dependencies: [
+    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+  ],
   targets: [
     .target(
       name: "AsyncAlgorithms"),


### PR DESCRIPTION
This enables the capability of building docs from commands like `swift package --disable-sandbox preview-documentation --target AsyncAlgorithms`