### PR TITLE
Only emit diagnostics for unexpected diagram mismatches

### DIFF
--- a/Tests/AsyncAlgorithmsTests/Support/ValidationTest.swift
+++ b/Tests/AsyncAlgorithmsTests/Support/ValidationTest.swift
@@ -14,10 +14,10 @@ import AsyncAlgorithms
 import AsyncSequenceValidation
 
 extension XCTestCase {
-  func recordFailure(_ description: String, detail: String? = nil, system: Bool = false, at location: AsyncSequenceValidation.SourceLocation) {
+  func recordFailure(_ description: String, system: Bool = false, at location: AsyncSequenceValidation.SourceLocation) {
 #if canImport(Darwin)
     let context = XCTSourceCodeContext(location: XCTSourceCodeLocation(filePath: location.file.description, lineNumber: Int(location.line)))
-    let issue = XCTIssue(type: system ? .system : .assertionFailure, compactDescription: description, detailedDescription: detail, sourceCodeContext: context, associatedError: nil, attachments: [])
+    let issue = XCTIssue(type: system ? .system : .assertionFailure, compactDescription: description, detailedDescription: nil, sourceCodeContext: context, associatedError: nil, attachments: [])
     record(issue)
 #else
     XCTFail(description, file: location.file, line: location.line)
@@ -26,30 +26,34 @@ extension XCTestCase {
   
   func validate<Test: AsyncSequenceValidationTest, Theme: AsyncSequenceValidationTheme>(theme: Theme, expectedFailures: Set<String>, @AsyncSequenceValidationDiagram _ build: (AsyncSequenceValidationDiagram) -> Test, file: StaticString = #file, line: UInt = #line) {
     var expectations = expectedFailures
+    var result: AsyncSequenceValidationDiagram.ExpectationResult?
+    var failures = [AsyncSequenceValidationDiagram.ExpectationFailure]()
     let baseLoc = AsyncSequenceValidation.SourceLocation(file: file, line: line)
+    var accountedFailures = [AsyncSequenceValidationDiagram.ExpectationFailure]()
     do {
-      let (result, failures) = try AsyncSequenceValidationDiagram.test(theme: theme, build)
-      var detail: String?
-      if failures.count > 0 {
-        detail = """
-        Expected
-        \(result.reconstituteExpected(theme: theme))
-        Actual
-        \(result.reconstituteActual(theme: theme))
-        """
-        print("Expected")
-        print(result.reconstituteExpected(theme: theme))
-        print("Actual")
-        print(result.reconstituteActual(theme: theme))
-      }
+      (result, failures) = try AsyncSequenceValidationDiagram.test(theme: theme, build)
       for failure in failures {
         if expectations.remove(failure.description) == nil {
-          recordFailure(failure.description, detail: detail, at: failure.specification?.location ?? baseLoc)
+          recordFailure(failure.description, at: failure.specification?.location ?? baseLoc)
+        } else {
+          accountedFailures.append(failure)
         }
       }
     } catch {
       if expectations.remove("\(error)") == nil {
         recordFailure("\(error)", system: true, at: (error as? SourceFailure)?.location ?? baseLoc)
+      }
+    }
+    // If no failures were expected and the result reconstitues to something different
+    // than what was expected, dump that out as a failure for easier diagnostics, this
+    // likely should be done via attachments but that does not display inline code
+    // nicely. Ideally we would want to have this display as a runtime warning but those
+    // do not have source line attribution; for now XCTFail is good enough.
+    if let result = result, expectedFailures.count == 0 {
+      let expected = result.reconstituteExpected(theme: theme)
+      let actual = result.reconstituteActual(theme: theme)
+      if expected != actual {
+        XCTFail("Validation failure:\nExpected:\n\(expected)\nActual:\n\(actual)", file: file, line: line)
       }
     }
     // any remaining expectations are failures that were expected but did not happen


### PR DESCRIPTION
When running the tests we should only emit reconstructions when the failure is unexpected AND when that reconstruction does not match the expected reconstruction. This also makes the reconstruction hints visible in Xcode as an error for easier indication of what happened.