### PR TITLE
Fix `TestRangeReplaceableCollection.swift` file name

### DIFF
--- a/Guides/Collections.md
+++ b/Guides/Collections.md
@@ -7,7 +7,7 @@
 [Source](https://github.com/apple/swift-async-algorithms/blob/main/Sources/AsyncAlgorithms/RangeReplaceableCollection.swift),
 [Source](https://github.com/apple/swift-async-algorithms/blob/main/Sources/AsyncAlgorithms/SetAlgebra.swift) |
 [Tests](https://github.com/apple/swift-async-algorithms/blob/main/Tests/AsyncAlgorithmsTests/TestDictionary.swift),
-[Tests](https://github.com/apple/swift-async-algorithms/blob/main/Tests/AsyncAlgorithmsTests/TestRangeReplacableCollection.swift),
+[Tests](https://github.com/apple/swift-async-algorithms/blob/main/Tests/AsyncAlgorithmsTests/TestRangeReplaceableCollection.swift),
 [Tests](https://github.com/apple/swift-async-algorithms/blob/main/Tests/AsyncAlgorithmsTests/TestSetAlgebra.swift),
 ]
 

--- a/Tests/AsyncAlgorithmsTests/TestRangeReplaceableCollection.swift
+++ b/Tests/AsyncAlgorithmsTests/TestRangeReplaceableCollection.swift
@@ -12,7 +12,7 @@
 import XCTest
 import AsyncAlgorithms
 
-final class TestRangeReplacableCollection: XCTestCase {
+final class TestRangeReplaceableCollection: XCTestCase {
   func test_String() async {
     let source = "abc"
     let expected = source


### PR DESCRIPTION
Renames `TestRangeReplacableCollection.swift` to `TestRangeReplaceableCollection.swift`.