### PR TITLE
#131 Cancel sends as if they were terminal events on task cancellation

### DIFF
--- a/Sources/AsyncAlgorithms/AsyncChannel.swift
+++ b/Sources/AsyncAlgorithms/AsyncChannel.swift
@@ -155,40 +155,69 @@ public final class AsyncChannel<Element: Sendable>: AsyncSequence, Sendable {
     }
   }
   
+  func cancelSend() {
+    let (sends, nexts) = state.withCriticalRegion { state -> ([UnsafeContinuation<UnsafeContinuation<Element?, Never>?, Never>], Set<Awaiting>) in
+      if state.terminal {
+        return ([], [])
+      }
+      state.terminal = true
+      switch state.emission {
+      case .idle:
+        return ([], [])
+      case .pending(let nexts):
+        state.emission = .idle
+        return (nexts, [])
+      case .awaiting(let nexts):
+        state.emission = .idle
+        return ([], nexts)
+      }
+    }
+    for send in sends {
+      send.resume(returning: nil)
+    }
+    for next in nexts {
+      next.continuation?.resume(returning: nil)
+    }
+  }
+  
   func _send(_ result: Result<Element?, Never>) async {
-    let continuation: UnsafeContinuation<Element?, Never>? = await withUnsafeContinuation { continuation in
-      state.withCriticalRegion { state -> UnsafeResumption<UnsafeContinuation<Element?, Never>?, Never>? in
-        if state.terminal {
-          return UnsafeResumption(continuation: continuation, success: nil)
-        }
-        switch result {
-        case .success(let value):
-          if value == nil {
+    await withTaskCancellationHandler {
+      cancelSend()
+    } operation: {
+      let continuation: UnsafeContinuation<Element?, Never>? = await withUnsafeContinuation { continuation in
+        state.withCriticalRegion { state -> UnsafeResumption<UnsafeContinuation<Element?, Never>?, Never>? in
+          if state.terminal {
+            return UnsafeResumption(continuation: continuation, success: nil)
+          }
+          switch result {
+          case .success(let value):
+            if value == nil {
+              state.terminal = true
+            }
+          case .failure:
             state.terminal = true
           }
-        case .failure:
-          state.terminal = true
-        }
-        switch state.emission {
-        case .idle:
-          state.emission = .pending([continuation])
-          return nil
-        case .pending(var sends):
-          sends.append(continuation)
-          state.emission = .pending(sends)
-          return nil
-        case .awaiting(var nexts):
-          let next = nexts.removeFirst().continuation
-          if nexts.count == 0 {
-            state.emission = .idle
-          } else {
-            state.emission = .awaiting(nexts)
+          switch state.emission {
+          case .idle:
+            state.emission = .pending([continuation])
+            return nil
+          case .pending(var sends):
+            sends.append(continuation)
+            state.emission = .pending(sends)
+            return nil
+          case .awaiting(var nexts):
+            let next = nexts.removeFirst().continuation
+            if nexts.count == 0 {
+              state.emission = .idle
+            } else {
+              state.emission = .awaiting(nexts)
+            }
+            return UnsafeResumption(continuation: continuation, success: next)
           }
-          return UnsafeResumption(continuation: continuation, success: next)
-        }
-      }?.resume()
+        }?.resume()
+      }
+      continuation?.resume(with: result)
     }
-    continuation?.resume(with: result)
   }
   
   /// Send an element to an awaiting iteration. This function will resume when the next call to `next()` is made.

--- a/Tests/AsyncAlgorithmsTests/TestChannel.swift
+++ b/Tests/AsyncAlgorithmsTests/TestChannel.swift
@@ -117,6 +117,36 @@ final class TestChannel: XCTestCase {
     XCTAssertNil(value)
   }
   
+  func test_sendCancellation() async {
+    let channel = AsyncChannel<Int>()
+    let notYetDone = expectation(description: "not yet done")
+    notYetDone.isInverted = true
+    let done = expectation(description: "done")
+    let task = Task {
+      await channel.send(1)
+      notYetDone.fulfill()
+      done.fulfill()
+    }
+    wait(for: [notYetDone], timeout: 0.1)
+    task.cancel()
+    wait(for: [done], timeout: 1.0)
+  }
+  
+  func test_sendCancellation_throwing() async {
+    let channel = AsyncThrowingChannel<Int, Error>()
+    let notYetDone = expectation(description: "not yet done")
+    notYetDone.isInverted = true
+    let done = expectation(description: "done")
+    let task = Task {
+      await channel.send(1)
+      notYetDone.fulfill()
+      done.fulfill()
+    }
+    wait(for: [notYetDone], timeout: 0.1)
+    task.cancel()
+    wait(for: [done], timeout: 1.0)
+  }
+  
   func test_cancellation_throwing() async throws {
     let channel = AsyncThrowingChannel<String, Error>()
     let ready = expectation(description: "ready")


### PR DESCRIPTION
This makes AsyncChannel and AsyncThrowing channel no longer cause tasks to hang when they are cancelled. 