### PR TITLE
#113 Define the first element of throttled sequences by not exceeding  the rate (and fix a expectation misalignment of events)

### DIFF
--- a/Guides/Throttle.md
+++ b/Guides/Throttle.md
@@ -77,6 +77,8 @@ extension AsyncThrottleSequence.Iterator: Sendable
 
 The `AsyncThrottleSequence` and its `Iterator` are conditionally `Sendable` if the base types comprising it are `Sendable`.
 
+The time in which events are measured are from the previous emission if present. If a duration has elapsed between the last emission and the point in time the throttle is measured then that duration is counted as elapsed. The first element is considered not throttled because no interval can be constructed from the start to the first element.
+
 ## Alternatives Considered
 
 It was considered to only provide the "latest" style APIs, however the reduction version grants more flexibility and can act as a funnel to the implementations of `latest`.

--- a/Sources/AsyncSequenceValidation/Expectation.swift
+++ b/Sources/AsyncSequenceValidation/Expectation.swift
@@ -42,7 +42,7 @@ extension AsyncSequenceValidationDiagram {
     }
     
     func reconstitute<Theme: AsyncSequenceValidationTheme>(_ events: [Clock.Instant : [Result<String?, Error>]], theme: Theme, end: Clock.Instant) -> String {
-      var now = Clock.Instant(when: .zero)
+      var now = Clock.Instant(when: .steps(1)) // adjust for the offset index
       var reconstituted = ""
       while now <= end {
         if let results = events[now] {

--- a/Tests/AsyncAlgorithmsTests/TestThrottle.swift
+++ b/Tests/AsyncAlgorithmsTests/TestThrottle.swift
@@ -49,7 +49,7 @@ final class TestThrottle: XCTestCase {
     validate {
       "abcdefghijk|"
       $0.inputs[0].throttle(for: .steps(2), clock: $0.clock)
-      "-b-d-f-h-j-|"
+      "a-c-e-g-i-k|"
     }
   }
   
@@ -57,7 +57,7 @@ final class TestThrottle: XCTestCase {
     validate {
       "abcdefghijk|"
       $0.inputs[0].throttle(for: .steps(2), clock: $0.clock, latest: false)
-      "-a-c-e-g-i-|"
+      "a-b-d-f-h-j|"
     }
   }
   
@@ -65,7 +65,7 @@ final class TestThrottle: XCTestCase {
     validate {
       "abcdefghijk|"
       $0.inputs[0].throttle(for: .steps(3), clock: $0.clock)
-      "--c--f--i--|"
+      "a--d--g--j-|"
     }
   }
   
@@ -73,7 +73,7 @@ final class TestThrottle: XCTestCase {
     validate {
       "abcdefghijk|"
       $0.inputs[0].throttle(for: .steps(3), clock: $0.clock, latest: false)
-      "--a--d--g--|"
+      "a--b--e--h-|"
     }
   }
   
@@ -81,7 +81,7 @@ final class TestThrottle: XCTestCase {
     validate {
       "abcdef^hijk|"
       $0.inputs[0].throttle(for: .steps(2), clock: $0.clock)
-      "-b-d-f^"
+      "a-c-e-^"
     }
   }
   
@@ -89,7 +89,7 @@ final class TestThrottle: XCTestCase {
     validate {
       "abcdef^hijk|"
       $0.inputs[0].throttle(for: .steps(2), clock: $0.clock, latest: false)
-      "-a-c-e^"
+      "a-b-d-^"
     }
   }
   
@@ -121,7 +121,7 @@ final class TestThrottle: XCTestCase {
     validate {
       "-a-b-c-d-e-f-g-h-i-j-k-|"
       $0.inputs[0].throttle(for: .steps(3), clock: $0.clock)
-      "---b---d---f---h---j---|"
+      "-a---c---e---g---i---k-|"
     }
   }
 }


### PR DESCRIPTION
This resolves #113 by defining the first element as not exceeding the reduction of the duration. 

Fixing that caused a related issue with the validation reconstruction to show a mis-alignment of the events. 