### PR TITLE
Fix redundant where clauses in `AsyncBufferSequence` extension

### DIFF
--- a/Sources/AsyncAlgorithms/AsyncBufferSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncBufferSequence.swift
@@ -234,8 +234,8 @@ public struct AsyncBufferSequence<Base: AsyncSequence, Buffer: AsyncBuffer> wher
   }
 }
 
-extension AsyncBufferSequence: Sendable where Base: Sendable, Base.AsyncIterator: Sendable, Base.Element: Sendable { }
-extension AsyncBufferSequence.Iterator: Sendable where Base: Sendable, Base.AsyncIterator: Sendable, Base.Element: Sendable { }
+extension AsyncBufferSequence: Sendable where Base: Sendable { }
+extension AsyncBufferSequence.Iterator: Sendable where Base: Sendable { }
 
 extension AsyncBufferSequence: AsyncSequence {
   public typealias Element = Buffer.Output


### PR DESCRIPTION
# Goal

To fix two warnings regarding redundant conformance constraints in `AsyncBufferSequence`:

<img width="1368" alt="Screen Shot 2022-04-08 at 21 25 57" src="https://user-images.githubusercontent.com/6910889/162549232-07f9ba6f-417b-4fd6-9126-75aee3ed6bf3.png">
