### PR TITLE
`AsyncChannel` fixes potential crashes when no more awaiting

### DIFF
--- a/Sources/AsyncAlgorithms/AsyncChannel.swift
+++ b/Sources/AsyncAlgorithms/AsyncChannel.swift
@@ -89,7 +89,11 @@ public final class AsyncChannel<Element: Sendable>: AsyncSequence, Sendable {
       switch self {
       case .awaiting(var awaiting):
         let continuation = awaiting.remove(Awaiting(placeholder: generation))?.continuation
-        self = .awaiting(awaiting)
+        if awaiting.isEmpty {
+          self = .idle
+        } else {
+          self = .awaiting(awaiting)
+        }
         return continuation
       case .idle:
         self = .awaiting([Awaiting(cancelled: generation)])
@@ -145,7 +149,11 @@ public final class AsyncChannel<Element: Sendable>: AsyncSequence, Sendable {
             nexts.remove(Awaiting(placeholder: generation))
             cancelled = true
           }
-          state.emission = .awaiting(nexts)
+          if nexts.isEmpty {
+            state.emission = .idle
+          } else {
+            state.emission = .awaiting(nexts)
+          }
           return nil
         }
       }?.resume()


### PR DESCRIPTION
This PR fixes potential crashes where the state is "awaiting" while there are no more awaiting clients.
The state is now set to .idle to reflect the reality.

This PR is linked to the issue #142.

The fix prevents the `removeFirst()` to be executed by preemptively setting the state to a correct value. It think the `removeFirst()` statements should be used in a more secure fashion though. It could be the subject of another PR.

It is hard to produce unit tests that ensure the crashes are fixed since we must set the AsyncChannel in an awaiting state. Ideas are welcome  !