### PR TITLE
asyncThrowingChannel: fixes potential crashes when no more awaiting

### DIFF
--- a/Sources/AsyncAlgorithms/AsyncThrowingChannel.swift
+++ b/Sources/AsyncAlgorithms/AsyncThrowingChannel.swift
@@ -88,7 +88,11 @@ public final class AsyncThrowingChannel<Element: Sendable, Failure: Error>: Asyn
       switch self {
       case .awaiting(var awaiting):
         let continuation = awaiting.remove(Awaiting(placeholder: generation))?.continuation
-        self = .awaiting(awaiting)
+        if awaiting.isEmpty {
+           self = .idle
+         } else {
+           self = .awaiting(awaiting)
+         }
         return continuation
       case .idle:
         self = .awaiting([Awaiting(cancelled: generation)])
@@ -143,7 +147,11 @@ public final class AsyncThrowingChannel<Element: Sendable, Failure: Error>: Asyn
             nexts.remove(Awaiting(placeholder: generation))
             cancelled = true
           }
-          state.emission = .awaiting(nexts)
+          if nexts.isEmpty {
+             state.emission = .idle
+           } else {
+             state.emission = .awaiting(nexts)
+           }
           return nil
         }
       }?.resume()


### PR DESCRIPTION
This PR is the sister from this one https://github.com/apple/swift-async-algorithms/pull/143 but for `AsyncThrowingChannel` that suffers from the very same issue.

The issue is described here: https://github.com/apple/swift-async-algorithms/issues/142

Before this PR, an `AsyncThrowingChannel` could crash in the following context:

- start an iteration in a Task
- cancel the task while the `AsyncThrowingChannel` is being awaited
- send a value in the channel

An issue has already been created to track the implementation of unit tests to ensure non regression: https://github.com/apple/swift-async-algorithms/issues/148