### PR TITLE
zip: improve unit tests readability

### DIFF
--- a/Tests/AsyncAlgorithmsTests/TestZip.swift
+++ b/Tests/AsyncAlgorithmsTests/TestZip.swift
@@ -13,111 +13,129 @@
 import AsyncAlgorithms
 
 final class TestZip2: XCTestCase {
-  func test_zip() async {
+  func test_zip_makes_sequence_equivalent_to_synchronous_zip_when_all_sequences_have_same_size() async {
     let a = [1, 2, 3]
     let b = ["a", "b", "c"]
+
     let expected = Array(zip(a, b))
     let actual = await Array(zip(a.async, b.async))
     XCTAssertEqual(expected, actual)
   }
   
-  func test_zip_first_longer() async {
+  func test_zip_makes_sequence_equivalent_to_synchronous_zip_when_first_is_longer() async {
     let a = [1, 2, 3, 4, 5]
     let b = ["a", "b", "c"]
+
     let expected = Array(zip(a, b))
     let actual = await Array(zip(a.async, b.async))
     XCTAssertEqual(expected, actual)
   }
   
-  func test_zip_second_longer() async {
+  func test_zip_makes_sequence_equivalent_to_synchronous_zip_when_second_is_longer() async {
     let a = [1, 2, 3]
     let b = ["a", "b", "c", "d", "e"]
+
     let expected = Array(zip(a, b))
     let actual = await Array(zip(a.async, b.async))
     XCTAssertEqual(expected, actual)
   }
   
-  func test_iterate_past_end() async {
+  func test_zip_produces_nil_next_element_when_iteration_is_finished_and_all_sequences_have_same_size() async {
     let a = [1, 2, 3]
     let b = ["a", "b", "c"]
     let sequence = zip(a.async, b.async)
     var iterator = sequence.makeAsyncIterator()
+
+    let expected = Array(zip(a, b))
     var collected = [(Int, String)]()
     while let item = await iterator.next() {
       collected.append(item)
     }
-    XCTAssertEqual([(1, "a"), (2, "b"), (3, "c")], collected)
+    XCTAssertEqual(expected, collected)
+
     let pastEnd = await iterator.next()
     XCTAssertNil(pastEnd)
   }
   
-  func test_iterate_past_end_first_longer() async {
+  func test_zip_produces_nil_next_element_when_iteration_is_finished_and_first_is_longer() async {
     let a = [1, 2, 3, 4, 5]
     let b = ["a", "b", "c"]
     let sequence = zip(a.async, b.async)
     var iterator = sequence.makeAsyncIterator()
+
+    let expected = Array(zip(a, b))
     var collected = [(Int, String)]()
     while let item = await iterator.next() {
       collected.append(item)
     }
-    XCTAssertEqual([(1, "a"), (2, "b"), (3, "c")], collected)
+    XCTAssertEqual(expected, collected)
+
     let pastEnd = await iterator.next()
     XCTAssertNil(pastEnd)
   }
   
-  func test_iterate_past_end_second_longer() async {
+  func test_zip_produces_nil_next_element_when_iteration_is_finished_and_second_is_longer() async {
     let a = [1, 2, 3]
     let b = ["a", "b", "c", "d", "e"]
     let sequence = zip(a.async, b.async)
     var iterator = sequence.makeAsyncIterator()
+
+    let expected = Array(zip(a, b))
     var collected = [(Int, String)]()
     while let item = await iterator.next() {
       collected.append(item)
     }
-    XCTAssertEqual([(1, "a"), (2, "b"), (3, "c")], collected)
+    XCTAssertEqual(expected, collected)
+
     let pastEnd = await iterator.next()
     XCTAssertNil(pastEnd)
   }
   
-  func test_first_throwing() async throws {
+  func test_zip_produces_one_element_and_throws_when_first_produces_one_element_and_throws() async throws {
     let a = [1, 2, 3]
     let b = ["a", "b", "c"]
     let sequence = zip(a.async.map { try throwOn(2, $0) }, b.async)
     var iterator = sequence.makeAsyncIterator()
+
+    let expected = [(1, "a")]
     var collected = [(Int, String)]()
     do {
       while let item = try await iterator.next() {
         collected.append(item)
       }
-      XCTFail()
+      XCTFail("Zipped sequence should throw after one collected element")
     } catch {
       XCTAssertEqual(Failure(), error as? Failure)
     }
-    XCTAssertEqual([(1, "a")], collected)
+    XCTAssertEqual(expected, collected)
+
     let pastEnd = try await iterator.next()
     XCTAssertNil(pastEnd)
   }
   
-  func test_second_throwing() async throws {
+  func test_zip_produces_one_element_and_throws_when_second_produces_one_element_and_throws() async throws {
     let a = [1, 2, 3]
     let b = ["a", "b", "c"]
     let sequence = zip(a.async, b.async.map { try throwOn("b", $0) })
     var iterator = sequence.makeAsyncIterator()
+
+    let expected = [(1, "a")]
     var collected = [(Int, String)]()
     do {
       while let item = try await iterator.next() {
         collected.append(item)
       }
-      XCTFail()
+      XCTFail("Zipped sequence should throw after one collected element")
     } catch {
       XCTAssertEqual(Failure(), error as? Failure)
     }
-    XCTAssertEqual([(1, "a")], collected)
+    XCTAssertEqual(expected, collected)
+
     let pastEnd = try await iterator.next()
     XCTAssertNil(pastEnd)
   }
   
-  func test_cancellation() async {
+  func test_zip_finishes_when_iteration_task_is_cancelled() async {
     let source1 = Indefinite(value: "test1")
     let source2 = Indefinite(value: "test2")
     let sequence = zip(source1.async, source2.async)
@@ -143,159 +161,188 @@ final class TestZip2: XCTestCase {
 }
 
 final class TestZip3: XCTestCase {
-  func test_zip() async {
+  func test_zip_makes_sequence_equivalent_to_synchronous_zip_when_all_sequences_have_same_size() async {
     let a = [1, 2, 3]
     let b = ["a", "b", "c"]
     let c = [1, 2, 3]
+
+    let expected = [(1, "a", 1), (2, "b", 2), (3, "c", 3)]
     let actual = await Array(zip(a.async, b.async, c.async))
-    XCTAssertEqual([(1, "a", 1), (2, "b", 2), (3, "c", 3)], actual)
+    XCTAssertEqual(expected, actual)
   }
   
-  func test_zip_first_longer() async {
+  func test_zip_makes_sequence_equivalent_to_synchronous_zip_when_first_is_longer() async {
     let a = [1, 2, 3, 4, 5]
     let b = ["a", "b", "c"]
     let c = [1, 2, 3]
+
+    let expected = [(1, "a", 1), (2, "b", 2), (3, "c", 3)]
     let actual = await Array(zip(a.async, b.async, c.async))
-    XCTAssertEqual([(1, "a", 1), (2, "b", 2), (3, "c", 3)], actual)
+    XCTAssertEqual(expected, actual)
   }
   
-  func test_zip_second_longer() async {
+  func test_zip_makes_sequence_equivalent_to_synchronous_zip_when_second_is_longer() async {
     let a = [1, 2, 3]
     let b = ["a", "b", "c", "d", "e"]
     let c = [1, 2, 3]
+
+    let expected = [(1, "a", 1), (2, "b", 2), (3, "c", 3)]
     let actual = await Array(zip(a.async, b.async, c.async))
-    XCTAssertEqual([(1, "a", 1), (2, "b", 2), (3, "c", 3)], actual)
+    XCTAssertEqual(expected, actual)
   }
   
-  func test_zip_third_longer() async {
+  func test_zip_makes_sequence_equivalent_to_synchronous_zip_when_third_is_longer() async {
     let a = [1, 2, 3]
     let b = ["a", "b", "c"]
     let c = [1, 2, 3, 4, 5]
+
+    let expected = [(1, "a", 1), (2, "b", 2), (3, "c", 3)]
     let actual = await Array(zip(a.async, b.async, c.async))
-    XCTAssertEqual([(1, "a", 1), (2, "b", 2), (3, "c", 3)], actual)
+    XCTAssertEqual(expected, actual)
   }
   
-  func test_iterate_past_end() async {
+  func test_zip_produces_nil_next_element_when_iteration_is_finished_and_all_sequences_have_same_size() async {
     let a = [1, 2, 3]
     let b = ["a", "b", "c"]
     let c = [1, 2, 3]
     let sequence = zip(a.async, b.async, c.async)
     var iterator = sequence.makeAsyncIterator()
+
+    let expected = [(1, "a", 1), (2, "b", 2), (3, "c", 3)]
     var collected = [(Int, String, Int)]()
     while let item = await iterator.next() {
       collected.append(item)
     }
-    XCTAssertEqual([(1, "a", 1), (2, "b", 2), (3, "c", 3)], collected)
+    XCTAssertEqual(expected, collected)
+
     let pastEnd = await iterator.next()
     XCTAssertNil(pastEnd)
   }
   
-  func test_iterate_past_end_first_longer() async {
+  func test_zip_produces_nil_next_element_when_iteration_is_finished_and_first_is_longer() async {
     let a = [1, 2, 3, 4, 5]
     let b = ["a", "b", "c"]
     let c = [1, 2, 3]
     let sequence = zip(a.async, b.async, c.async)
     var iterator = sequence.makeAsyncIterator()
+
+    let expected = [(1, "a", 1), (2, "b", 2), (3, "c", 3)]
     var collected = [(Int, String, Int)]()
     while let item = await iterator.next() {
       collected.append(item)
     }
-    XCTAssertEqual([(1, "a", 1), (2, "b", 2), (3, "c", 3)], collected)
+    XCTAssertEqual(expected, collected)
+
     let pastEnd = await iterator.next()
     XCTAssertNil(pastEnd)
   }
   
-  func test_iterate_past_end_second_longer() async {
+  func test_zip_produces_nil_next_element_when_iteration_is_finished_and_second_is_longer() async {
     let a = [1, 2, 3]
     let b = ["a", "b", "c", "d", "e"]
     let c = [1, 2, 3]
     let sequence = zip(a.async, b.async, c.async)
     var iterator = sequence.makeAsyncIterator()
+
+    let expected = [(1, "a", 1), (2, "b", 2), (3, "c", 3)]
     var collected = [(Int, String, Int)]()
     while let item = await iterator.next() {
       collected.append(item)
     }
-    XCTAssertEqual([(1, "a", 1), (2, "b", 2), (3, "c", 3)], collected)
+    XCTAssertEqual(expected, collected)
+
     let pastEnd = await iterator.next()
     XCTAssertNil(pastEnd)
   }
   
-  func test_iterate_past_end_third_longer() async {
+  func test_zip_produces_nil_next_element_when_iteration_is_finished_and_third_is_longer() async {
     let a = [1, 2, 3]
     let b = ["a", "b", "c"]
     let c = [1, 2, 3, 4, 5]
     let sequence = zip(a.async, b.async, c.async)
     var iterator = sequence.makeAsyncIterator()
+
+    let expected = [(1, "a", 1), (2, "b", 2), (3, "c", 3)]
     var collected = [(Int, String, Int)]()
     while let item = await iterator.next() {
       collected.append(item)
     }
-    XCTAssertEqual([(1, "a", 1), (2, "b", 2), (3, "c", 3)], collected)
+    XCTAssertEqual(expected, collected)
+
     let pastEnd = await iterator.next()
     XCTAssertNil(pastEnd)
   }
   
-  func test_first_throwing() async throws {
+  func test_zip_produces_one_element_and_throws_when_first_produces_one_element_and_throws() async throws {
     let a = [1, 2, 3]
     let b = ["a", "b", "c"]
     let c = [1, 2, 3]
     let sequence = zip(a.async.map { try throwOn(2, $0) }, b.async, c.async)
     var iterator = sequence.makeAsyncIterator()
+
+    let expected = [(1, "a", 1)]
     var collected = [(Int, String, Int)]()
     do {
       while let item = try await iterator.next() {
         collected.append(item)
       }
-      XCTFail()
+      XCTFail("Zipped sequence should throw after one collected element")
     } catch {
       XCTAssertEqual(Failure(), error as? Failure)
     }
-    XCTAssertEqual([(1, "a", 1)], collected)
+    XCTAssertEqual(expected, collected)
+
     let pastEnd = try await iterator.next()
     XCTAssertNil(pastEnd)
   }
   
-  func test_second_throwing() async throws {
+  func test_zip_produces_one_element_and_throws_when_second_produces_one_element_and_throws() async throws {
     let a = [1, 2, 3]
     let b = ["a", "b", "c"]
     let c = [1, 2, 3]
     let sequence = zip(a.async, b.async.map { try throwOn("b", $0) }, c.async)
     var iterator = sequence.makeAsyncIterator()
+
+    let expected = [(1, "a", 1)]
     var collected = [(Int, String, Int)]()
     do {
       while let item = try await iterator.next() {
         collected.append(item)
       }
-      XCTFail()
+      XCTFail("Zipped sequence should throw after one collected element")
     } catch {
       XCTAssertEqual(Failure(), error as? Failure)
     }
-    XCTAssertEqual([(1, "a", 1)], collected)
+    XCTAssertEqual(expected, collected)
+
     let pastEnd = try await iterator.next()
     XCTAssertNil(pastEnd)
   }
   
-  func test_third_throwing() async throws {
+  func test_zip_produces_one_element_and_throws_when_third_produces_one_element_and_throws() async throws {
     let a = [1, 2, 3]
     let b = ["a", "b", "c"]
     let c = [1, 2, 3]
     let sequence = zip(a.async, b.async, c.async.map { try throwOn(2, $0) })
     var iterator = sequence.makeAsyncIterator()
+
+    let expected = [(1, "a", 1)]
     var collected = [(Int, String, Int)]()
     do {
       while let item = try await iterator.next() {
         collected.append(item)
       }
-      XCTFail()
+      XCTFail("Zipped sequence should throw after one collected element")
     } catch {
       XCTAssertEqual(Failure(), error as? Failure)
     }
-    XCTAssertEqual([(1, "a", 1)], collected)
+    XCTAssertEqual(expected, collected)
+
     let pastEnd = try await iterator.next()
     XCTAssertNil(pastEnd)
   }
   
-  func test_cancellation() async {
+  func test_zip_finishes_when_iteration_task_is_cancelled() async {
     let source1 = Indefinite(value: "test1")
     let source2 = Indefinite(value: "test2")
     let source3 = Indefinite(value: "test3")


### PR DESCRIPTION
Hi,

This PR is a try to clarify/harmonize the unit tests for the `zip` functions.

the convention for test names is: `func test_systemUnderTest_expectedResult_when_conditionsOfTest() {}`

The pattern : `expected` / `actual/collected` has been extended to all tests.

If this initiative is successful then we could apply the same convention to other tests.