### PR TITLE
Fix async channel finishes all

### DIFF
--- a/Sources/AsyncAlgorithms/AsyncAlgorithms.docc/Guides/Channel.md
+++ b/Sources/AsyncAlgorithms/AsyncAlgorithms.docc/Guides/Channel.md
@@ -14,7 +14,7 @@
 
 ## Proposed Solution
 
-To achieve a system that supports back pressure and allows for the communication of more than one value from one task to another we are introducing a new type, the _channel_. The channel will be a reference-type asynchronous sequence with an asynchronous sending capability that awaits the consumption of iteration. Each value sent by the channel, or finish transmitted, will await the consumption of that value or event by iteration. That awaiting behavior will allow for the affordance of back pressure applied from the consumption site to be transmitted to the production site. This means that the rate of production cannot exceed the rate of consumption, and that the rate of consumption cannot exceed the rate of production.
+To achieve a system that supports back pressure and allows for the communication of more than one value from one task to another we are introducing a new type, the _channel_. The channel will be a reference-type asynchronous sequence with an asynchronous sending capability that awaits the consumption of iteration. Each value sent by the channel will await the consumption of that value by iteration. That awaiting behavior will allow for the affordance of back pressure applied from the consumption site to be transmitted to the production site. This means that the rate of production cannot exceed the rate of consumption, and that the rate of consumption cannot exceed the rate of production. Sending a terminal event to the channel will instantly resume all pending operations for every producers and consumers.
 
 ## Detailed Design
 

--- a/Sources/AsyncAlgorithms/AsyncThrowingChannel.swift
+++ b/Sources/AsyncAlgorithms/AsyncThrowingChannel.swift
@@ -129,10 +129,10 @@ public final class AsyncThrowingChannel<Element: Sendable, Failure: Error>: Asyn
   func next(_ generation: Int) async throws -> Element? {
     return try await withUnsafeThrowingContinuation { continuation in
       var cancelled = false
-      var isTerminal = false
+      var terminal = false
       state.withCriticalRegion { state -> UnsafeResumption<UnsafeContinuation<Element?, Error>?, Never>? in
         if state.terminal {
-          isTerminal = true
+          terminal = true
           return nil
         }
         switch state.emission {
@@ -160,7 +160,7 @@ public final class AsyncThrowingChannel<Element: Sendable, Failure: Error>: Asyn
           return nil
         }
       }?.resume()
-      if cancelled || isTerminal {
+      if cancelled || terminal {
         continuation.resume(returning: nil)
       }
     }

--- a/Sources/AsyncAlgorithms/AsyncThrowingChannel.swift
+++ b/Sources/AsyncAlgorithms/AsyncThrowingChannel.swift
@@ -129,7 +129,12 @@ public final class AsyncThrowingChannel<Element: Sendable, Failure: Error>: Asyn
   func next(_ generation: Int) async throws -> Element? {
     return try await withUnsafeThrowingContinuation { continuation in
       var cancelled = false
+      var isTerminal = false
       state.withCriticalRegion { state -> UnsafeResumption<UnsafeContinuation<Element?, Error>?, Never>? in
+        if state.terminal {
+          isTerminal = true
+          return nil
+        }
         switch state.emission {
         case .idle:
           state.emission = .awaiting([Awaiting(generation: generation, continuation: continuation)])
@@ -155,13 +160,13 @@ public final class AsyncThrowingChannel<Element: Sendable, Failure: Error>: Asyn
           return nil
         }
       }?.resume()
-      if cancelled {
+      if cancelled || isTerminal {
         continuation.resume(returning: nil)
       }
     }
   }
   
-  func cancelSend() {
+  func finishAll() {
     let (sends, nexts) = state.withCriticalRegion { state -> ([UnsafeContinuation<UnsafeContinuation<Element?, Error>?, Never>], Set<Awaiting>) in
       if state.terminal {
         return ([], [])
@@ -186,23 +191,20 @@ public final class AsyncThrowingChannel<Element: Sendable, Failure: Error>: Asyn
     }
   }
   
-  func _send(_ result: Result<Element?, Error>) async {
+  func _send(_ result: Result<Element, Error>) async {
     await withTaskCancellationHandler {
-      cancelSend()
+      finishAll()
     } operation: {
       let continuation: UnsafeContinuation<Element?, Error>? = await withUnsafeContinuation { continuation in
         state.withCriticalRegion { state -> UnsafeResumption<UnsafeContinuation<Element?, Error>?, Never>? in
           if state.terminal {
             return UnsafeResumption(continuation: continuation, success: nil)
           }
-          switch result {
-          case .success(let value):
-            if value == nil {
-              state.terminal = true
-            }
-          case .failure:
+
+          if case .failure = result {
             state.terminal = true
           }
+          
           switch state.emission {
           case .idle:
             state.emission = .pending([continuation])
@@ -222,7 +224,7 @@ public final class AsyncThrowingChannel<Element: Sendable, Failure: Error>: Asyn
           }
         }?.resume()
       }
-      continuation?.resume(with: result)
+      continuation?.resume(with: result.map { $0 as Element? })
     }
   }
   
@@ -238,10 +240,9 @@ public final class AsyncThrowingChannel<Element: Sendable, Failure: Error>: Asyn
     await _send(.failure(error))
   }
   
-  /// Send a finish to an awaiting iteration. This function will resume when the next call to `next()` is made.
-  /// If the channel is already finished then this returns immediately
-  public func finish() async {
-      await _send(.success(nil))
+  /// Send a finish to all awaiting iterations.
+  public func finish() {
+    finishAll()
   }
   
   public func makeAsyncIterator() -> Iterator {


### PR DESCRIPTION
This PR aims to fix/improve the "finish" strategy for `AsyncChannel`/`AsyncThrowingChannel`.

From my understanding there are two possible scenarios when sending a finish:

**- 1:** There are no awaiting clients. There are potential pending "send" operations. We send finish 1 or several times.
**- 2:** There are no pending operations. There are several awaiting clients. We send finish 1 or several times.

The current behaviour is:

**- 1:** The state is set to `terminal`. Finish is added as a pending operation (other future finishes or values will be discarded). The future clients will consume the pending operations until they reach the finish operation. Once a client has consumed this finish operation, the next potential awaiting clients will be suspended for ever.
**- 2:** The state is set to `terminal`. The first awaiting operation is resumed with the nil value. The potential other awaiting operations won't be resumed. There is also infinite suspensions for them.

The behaviour with this PR is: 

**- 1 and 2:** All pending and awaiting operations are resumed with nil (other furure finishes or values will be discarded). The potential futur clients will be instantly resumed with nil.

Some considerations that might trigger questions:
- the `finish` function is no more async since it does not involve the creation of a continuation.
- If there are several pending operations when finish is called, they will be discarded, meaning that if we have several Tasks that send values in a `Channel` and one of them call `finish` then some potential suspended `send` in other tasks will be resumed instantly and their value will never be emitted.
- Unit testing the scenario where `finish` is called while several clients are already awaiting is difficult because there is no way to wait for the `next` function to be called before calling `finish`. Ideas are welcome.

This PR addresses the issue described here -> https://github.com/apple/swift-async-algorithms/issues/136