### PR TITLE
Test sleeping in both tasks of Task.select.

### DIFF
--- a/Tests/AsyncAlgorithmsTests/TestTaskSelect.swift
+++ b/Tests/AsyncAlgorithmsTests/TestTaskSelect.swift
@@ -16,6 +16,7 @@ import AsyncAlgorithms
 final class TestTaskSelect: XCTestCase {
   func test_first() async {
     let firstValue = await Task.select(Task {
+      try! await Task.sleep(until: .now + .microseconds(100), clock: .continuous)
       return 1
     }, Task {
       try! await Task.sleep(until: .now + .seconds(2), clock: .continuous)
@@ -29,6 +30,7 @@ final class TestTaskSelect: XCTestCase {
       try! await Task.sleep(until: .now + .seconds(2), clock: .continuous)
       return 1
     }, Task {
+      try! await Task.sleep(until: .now + .microseconds(100), clock: .continuous)
       return 2
     }).value
     XCTAssertEqual(firstValue, 2)
@@ -40,6 +42,7 @@ final class TestTaskSelect: XCTestCase {
         try await Task.sleep(until: .now + .seconds(2), clock: .continuous)
         return 1
       }, Task { () async throws -> Int in
+        try! await Task.sleep(until: .now + .microseconds(100), clock: .continuous)
         throw NSError(domain: NSCocoaErrorDomain, code: -1, userInfo: nil)
       }).value
       XCTFail()


### PR DESCRIPTION
This makes it so that each task in `Task.select` sleeps so that we get test coverage on the behavior I saw in #139 where the task would hang forever. The task does not hang forever if one of the selections is a non-awaiting block of code.

We don't need to sleep for any significant amount of time. I chose 100 microseconds, but it could even be a 0 duration sleep.