### PR TITLE
Improve Lock and ManagedCriticalState

### DIFF
--- a/Sources/AsyncAlgorithms/Locking.swift
+++ b/Sources/AsyncAlgorithms/Locking.swift
@@ -77,8 +77,8 @@ final class ManagedCriticalState<State> {
   }
   
   func withCriticalRegion<R>(_ critical: (inout State) throws -> R) rethrows -> R {
-    Lock.lock(lock)
-    defer { Lock.unlock(lock) }
+    Lock.lock(_lock)
+    defer { Lock.unlock(_lock) }
     return try critical(&_state)
   }
 }


### PR DESCRIPTION
- make Lock private
- make Lock safe to use instead of requiring manually deallocating
- turn ManagedCriticalState into a class instead of a class wrapped in a struct

Haven't found any tests or comments about why all this stuff is currently implemented the way it is. I'm on my Windows PC, so couldn't check if it compiles.