### PR TITLE
[AsyncThrowingChannel] make the `fail` terminal event non async

### DIFF
--- a/Sources/AsyncAlgorithms/AsyncAlgorithms.docc/Guides/Channel.md
+++ b/Sources/AsyncAlgorithms/AsyncAlgorithms.docc/Guides/Channel.md
@@ -44,14 +44,14 @@ public final class AsyncThrowingChannel<Element: Sendable, Failure: Error>: Asyn
   public init(element elementType: Element.Type = Element.self, failure failureType: Failure.Type = Failure.self)
   
   public func send(_ element: Element) async
-  public func fail(_ error: Error) async where Failure == Error
+  public func fail(_ error: Error) where Failure == Error
   public func finish()
   
   public func makeAsyncIterator() -> Iterator
 }
 ```
 
-Channels are intended to be used as communication types between tasks. Particularly when one task produces values and another task consumes said values. On the one hand, the back pressure applied by `send(_:)` and `fail(_:)` via the suspension/resume ensure that the production of values does not exceed the consumption of values from iteration. Each of these methods suspend after enqueuing the event and are resumed when the next call to `next()` on the `Iterator` is made. On the other hand, the call to `finish()` immediately resumes all the pending operations for every producers and consumers. Thus, every suspended `send(_:)` operations instantly resume, so as every suspended `next()` operations by producing a nil value, indicating the termination of the iterations. Further calls to `send(_:)` will immediately resume.
+Channels are intended to be used as communication types between tasks. Particularly when one task produces values and another task consumes said values. On the one hand, the back pressure applied by `send(_:)` via the suspension/resume ensures that the production of values does not exceed the consumption of values from iteration. This method suspends after enqueuing the event and is resumed when the next call to `next()` on the `Iterator` is made. On the other hand, the call to `finish()` or `fail(_:)` immediately resumes all the pending operations for every producers and consumers. Thus, every suspended `send(_:)` operations instantly resume, so as every suspended `next()` operations by producing a nil value, or by throwing an error, indicating the termination of the iterations. Further calls to `send(_:)` will immediately resume.
 
 ```swift
 let channel = AsyncChannel<String>()

--- a/Tests/AsyncAlgorithmsTests/TestChannel.swift
+++ b/Tests/AsyncAlgorithmsTests/TestChannel.swift
@@ -144,63 +144,6 @@ final class TestChannel: XCTestCase {
     wait(for: [additionalSend], timeout: 1.0)
   }
 
-  func test_asyncChannel_ends_alls_iterators_and_discards_additional_sent_values_when_finish_is_called2() async throws {
-    let channel = AsyncChannel<String>()
-    let complete = ManagedCriticalState(false)
-    let finished = expectation(description: "finished")
-
-    let valueFromConsumer1 = ManagedCriticalState<String?>(nil)
-    let valueFromConsumer2 = ManagedCriticalState<String?>(nil)
-
-    let received = expectation(description: "received")
-    received.expectedFulfillmentCount = 2
-
-    let pastEnd = expectation(description: "pastEnd")
-    pastEnd.expectedFulfillmentCount = 2
-
-    Task(priority: .high) {
-      var iterator = channel.makeAsyncIterator()
-      let ending = await iterator.next()
-      valueFromConsumer1.withCriticalRegion { $0 = ending }
-      received.fulfill()
-      let item = await iterator.next()
-      XCTAssertNil(item)
-      pastEnd.fulfill()
-    }
-
-    Task(priority: .high) {
-      var iterator = channel.makeAsyncIterator()
-      let ending = await iterator.next()
-      valueFromConsumer2.withCriticalRegion { $0 = ending }
-      received.fulfill()
-      let item = await iterator.next()
-      XCTAssertNil(item)
-      pastEnd.fulfill()
-    }
-
-    try await Task.sleep(nanoseconds: 1_000_000_000)
-
-    Task(priority: .low) {
-      channel.finish()
-      complete.withCriticalRegion { $0 = true }
-      finished.fulfill()
-    }
-
-    wait(for: [finished, received], timeout: 1.0)
-
-    XCTAssertTrue(complete.withCriticalRegion { $0 })
-    XCTAssertEqual(valueFromConsumer1.withCriticalRegion { $0 }, nil)
-    XCTAssertEqual(valueFromConsumer2.withCriticalRegion { $0 }, nil)
-
-    wait(for: [pastEnd], timeout: 1.0)
-    let additionalSend = expectation(description: "additional send")
-    Task {
-      await channel.send("test")
-      additionalSend.fulfill()
-    }
-    wait(for: [additionalSend], timeout: 1.0)
-  }
-
   func test_asyncThrowingChannel_ends_alls_iterators_and_discards_additional_sent_values_when_finish_is_called() async {
     let channel = AsyncThrowingChannel<String, Error>()
     let complete = ManagedCriticalState(false)


### PR DESCRIPTION
This PR is the sister of https://github.com/apple/swift-async-algorithms/pull/152 and is linked to that issue https://github.com/apple/swift-async-algorithms/issues/155.

Long story short: terminal events (finish/fail) should not imply a back pressure management since no further elements can be sent.

When fail is called:
- all pending and awaiting operations should be immediately resumed (in order to avoid potential infinite suspensions)
- further calls to `next()` will throw the error
- further calls to `send(_:)` will immediately resume
