### PR TITLE
[Compacted] rename unit tests

### DIFF
--- a/Tests/AsyncAlgorithmsTests/TestCompacted.swift
+++ b/Tests/AsyncAlgorithmsTests/TestCompacted.swift
@@ -13,7 +13,7 @@
 import AsyncAlgorithms
 
 final class TestCompacted: XCTestCase {
-  func test_compacting() async {
+  func test_compacted_is_equivalent_to_compactMap_when_input_as_nil_elements() async {
     let source = [1, 2, nil, 3, 4, nil, 5]
     let expected = source.compactMap { $0 }
     let sequence = source.async.compacted()
@@ -24,7 +24,7 @@ final class TestCompacted: XCTestCase {
     XCTAssertEqual(expected, actual)
   }
   
-  func test_compacting_past_end() async {
+  func test_compacted_produces_nil_next_element_when_iteration_is_finished() async {
     let source = [1, 2, nil, 3, 4, nil, 5]
     let expected = source.compactMap { $0 }
     let sequence = source.async.compacted()
@@ -38,7 +38,7 @@ final class TestCompacted: XCTestCase {
     XCTAssertNil(pastEnd)
   }
   
-  func test_compactingNonNils() async {
+  func test_compacted_is_equivalent_to_compactMap_when_input_as_no_nil_elements() async {
     let source: [Int?] = [1, 2, 3, 4, 5]
     let expected = source.compactMap { $0 }
     let sequence = source.async.compacted()
@@ -49,7 +49,7 @@ final class TestCompacted: XCTestCase {
     XCTAssertEqual(expected, actual)
   }
   
-  func test_throwing() async throws {
+  func test_compacted_throws_when_root_sequence_throws() async throws {
     let sequence = [1, nil, 3, 4, 5, nil, 7].async.map { try throwOn(4, $0) }.compacted()
     var iterator = sequence.makeAsyncIterator()
     var collected = [Int]()
@@ -66,7 +66,7 @@ final class TestCompacted: XCTestCase {
     XCTAssertNil(pastEnd)
   }
   
-  func test_cancellation() async {
+  func test_compacted_finishes_when_iteration_task_is_cancelled() async {
     let value: String? = "test"
     let source = Indefinite(value: value)
     let sequence = source.async.compacted()


### PR DESCRIPTION
This PR intends to improve the unit tests naming, just as we did for the zip, merge operator.