### PR TITLE
Ensure AsyncThrowingChannel reliably throws errors when racing against iteration

### DIFF
--- a/Tests/AsyncAlgorithmsTests/TestChannel.swift
+++ b/Tests/AsyncAlgorithmsTests/TestChannel.swift
@@ -75,6 +75,12 @@ final class TestChannel: XCTestCase {
     } catch {
       XCTAssertEqual(error as? Failure, Failure())
     }
+    do {
+      let value = try await iterator.next()
+      XCTAssertNil(value)
+    } catch {
+      XCTFail("Unexpected throw of error after iteration producing error")
+    }
   }
 
   func test_asyncChannel_ends_alls_iterators_and_discards_additional_sent_values_when_finish_is_called() async {


### PR DESCRIPTION
Another pull request (https://github.com/apple/swift-async-algorithms/pull/165) revealed a test that indicated flakiness in the potential terminal states of AsyncThrowingChannels when resolving to an error state. This ended up being that if the emission of the failure would happen before the iteration it would potentially set the state to finished, but not yield a failure, making subsequent calls to iteration produce nil.