### PR TITLE
Fix typo in Validation.md

### DIFF
--- a/Sources/AsyncSequenceValidation/AsyncSequenceValidation.docc/Validation.md
+++ b/Sources/AsyncSequenceValidation/AsyncSequenceValidation.docc/Validation.md
@@ -218,15 +218,15 @@ Access to the validation diagram input list is done through calls such as `$0.in
 |  Symbol | Token                     |  Description      | Example    |  
 | ------- | ------------------------- | ----------------- | ---------- |
 |   `-`   | `.step`                   | Advance time      | `"a--b--"` |
-|   `|`   | `.finish`                 | Termination       | `"ab-|"`   |
+|   `\|`   | `.finish`                 | Termination       | `"ab-\|"`   |
 |   `^`   | `.error`                  | Thrown error      | `"ab-^"`   |
 |   `;`   | `.cancel`                 | Cancellation      | `"ab;-"`   |
 |   `[`   | `.beginGroup`             | Begin group       | `"[ab]-"`  |
 |   `]`   | `.endGroup`               | End group         | `"[ab]-"`  |
 |   `'`   | `.beginValue` `.endValue` | Begin/End Value   | `"'foo'-"` |
 |   `,`   | `.delayNext`              | Delay next        | `",[a,]b"` |
-|   ` `   | `.skip`                   | Skip/Ignore       | `"a b- |"` |
-|         | `.value`                  | Values.           | `"ab-|"`   |
+|   ` `   | `.skip`                   | Skip/Ignore       | `"a b- \|"` |
+|         | `.value`                  | Values.           | `"ab-\|"`   |
 
 There are some diagram input specifications that are not valid. The three cases are:
 

--- a/Sources/AsyncSequenceValidation/AsyncSequenceValidation.docc/Validation.md
+++ b/Sources/AsyncSequenceValidation/AsyncSequenceValidation.docc/Validation.md
@@ -41,7 +41,7 @@ The syntax is trivially parsable (and consequently customizable). By default, th
 |  Symbol |  Description      | Example    |  
 | ------- | ----------------- | ---------- |
 |   `-`   | Advance time      | `"a--b--"` |
-|   `|`   | Termination       | `"ab-|"`   |
+|   `\|`  | Termination       | `"ab-\|"`  |
 |   `^`   | Thrown error      | `"ab-^"`   |
 |   `;`   | Cancellation      | `"ab;-"`   |
 |   `[`   | Begin group       | `"[ab]-"`  |


### PR DESCRIPTION
I think we need to add escaping characters before ` |`.