### PR TITLE
fixes tests for AsyncChannel which fail on iOS

### DIFF
--- a/Sources/AsyncAlgorithms_XCTest/AsyncExpectation.swift
+++ b/Sources/AsyncAlgorithms_XCTest/AsyncExpectation.swift
@@ -88,12 +88,10 @@ public actor AsyncExpectation {
     }
     
     let timeout = Task {
-      do {
-        try await Task.sleep(seconds: timeout)
-        for exp in expectations {
-          await exp.timeOut(file: file, line: line)
-        }
-      } catch {}
+      try? await Task.sleep(seconds: timeout)
+      for exp in expectations {
+        await exp.timeOut(file: file, line: line)
+      }
     }
     
     await waitUsingTaskGroup(expectations)
@@ -105,9 +103,7 @@ public actor AsyncExpectation {
     await withTaskGroup(of: Void.self) { group in
       for exp in expectations {
         group.addTask {
-          do {
-            try await exp.wait()
-          } catch {}
+          try? await exp.wait()
         }
       }
     }

--- a/Sources/AsyncAlgorithms_XCTest/AsyncExpectation.swift
+++ b/Sources/AsyncAlgorithms_XCTest/AsyncExpectation.swift
@@ -1,3 +1,14 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Async Algorithms open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
 import Foundation
 import XCTest
 
@@ -23,6 +34,10 @@ public actor AsyncExpectation {
   private var continuation: AsyncExpectationContinuation?
   private var state: State = .pending
   
+  public var isFulfilled: Bool {
+    state == .fulfilled
+  }
+  
   public init(description: String,
               isInverted: Bool = false,
               expectedFulfillmentCount: Int = 1) {
@@ -31,20 +46,19 @@ public actor AsyncExpectation {
     self.expectedFulfillmentCount = expectedFulfillmentCount
   }
   
-  public static func expectation(description: String,
-                                 isInverted: Bool = false,
-                                 expectedFulfillmentCount: Int = 1) -> AsyncExpectation {
-    AsyncExpectation(description: description,
-                     isInverted: isInverted,
-                     expectedFulfillmentCount: expectedFulfillmentCount)
-  }
-  
+  /// Marks the expectation as having been met.
+  ///
+  /// It is an error to call this method on an expectation that has already been fulfilled,
+  /// or when the test case that vended the expectation has already completed.
   public func fulfill(file: StaticString = #filePath, line: UInt = #line) {
     guard state != .fulfilled else { return }
     
-    guard !isInverted else {
-      XCTFail("Inverted expectation fulfilled: \(expectationDescription)", file: file, line: line)
-      finish()
+    if isInverted {
+      if state != .timedOut {
+        XCTFail("Inverted expectation fulfilled: \(expectationDescription)", file: file, line: line)
+        state = .fulfilled
+        finish()
+      }
       return
     }
     
@@ -59,13 +73,13 @@ public actor AsyncExpectation {
   public static func waitForExpectations(_ expectations: [AsyncExpectation],
                                          timeout: Double = 1.0,
                                          file: StaticString = #filePath,
-                                         line: UInt = #line) async throws {
+                                         line: UInt = #line) async {
     guard !expectations.isEmpty else { return }
     
     // check if all expectations are already satisfied and skip sleeping
     var count = 0
     for exp in expectations {
-      if await exp.state == .fulfilled {
+      if await exp.isFulfilled {
         count += 1
       }
     }
@@ -74,46 +88,60 @@ public actor AsyncExpectation {
     }
     
     let timeout = Task {
-      try await Task.sleep(seconds: timeout)
-      for exp in expectations {
-        await exp.timeOut(file: file, line: line)
-      }
+      do {
+        try await Task.sleep(seconds: timeout)
+        for exp in expectations {
+          await exp.timeOut(file: file, line: line)
+        }
+      } catch {}
     }
     
-    await withThrowingTaskGroup(of: Void.self) { group in
-      for exp in expectations {
-        group.addTask {
-          try await exp.wait()
-        }
-      }
-    }
+    await waitUsingTaskGroup(expectations)
     
     timeout.cancel()
   }
   
-  private func wait() async throws {
+  private static func waitUsingTaskGroup(_ expectations: [AsyncExpectation]) async {
+    await withTaskGroup(of: Void.self) { group in
+      for exp in expectations {
+        group.addTask {
+          do {
+            try await exp.wait()
+          } catch {}
+        }
+      }
+    }
+  }
+  
+  internal nonisolated func wait() async throws {
     try await withTaskCancellationHandler(handler: {
       Task {
         await cancel()
       }
     }, operation: {
-      if state == .fulfilled {
-        return
-      } else {
-        return try await withCheckedThrowingContinuation { (continuation: AsyncExpectationContinuation) in
-          self.continuation = continuation
-        }
-      }
+      try await handleWait()
     })
   }
   
-  private func timeOut(file: StaticString = #filePath,
-                       line: UInt = #line) async {
-    if state != .fulfilled && !isInverted {
+  internal func timeOut(file: StaticString = #filePath,
+                        line: UInt = #line) async {
+    if isInverted {
+      state = .timedOut
+    } else if state != .fulfilled {
       state = .timedOut
       XCTFail("Expectation timed out: \(expectationDescription)", file: file, line: line)
     }
     finish()
+  }
+  
+  private func handleWait() async throws {
+    if state == .fulfilled {
+      return
+    } else {
+      try await withCheckedThrowingContinuation { (continuation: AsyncExpectationContinuation) in
+        self.continuation = continuation
+      }
+    }
   }
   
   private func cancel() {

--- a/Sources/AsyncAlgorithms_XCTest/XCTestCase+AsyncTesting.swift
+++ b/Sources/AsyncAlgorithms_XCTest/XCTestCase+AsyncTesting.swift
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Async Algorithms open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import XCTest
+
+extension XCTestCase {
+  
+  /// Creates a new async expectation with an associated description.
+  ///
+  /// Use this method to create ``AsyncExpectation`` instances that can be
+  /// fulfilled when asynchronous tasks in your tests complete.
+  ///
+  /// To fulfill an expectation that was created with `asyncExpectation(description:)`,
+  /// call the expectation's `fulfill()` method when the asynchronous task in your
+  /// test has completed.
+  ///
+  /// - Parameters:
+  ///   - description: A string to display in the test log for this expectation, to help diagnose failures.
+  ///   - isInverted: Indicates that the expectation is not intended to happen.
+  ///   - expectedFulfillmentCount: The number of times fulfill() must be called before the expectation is completely fulfilled. (default = 1)
+  public func asyncExpectation(description: String,
+                               isInverted: Bool = false,
+                               expectedFulfillmentCount: Int = 1) -> AsyncExpectation {
+    AsyncExpectation(description: description,
+                     isInverted: isInverted,
+                     expectedFulfillmentCount: expectedFulfillmentCount)
+  }
+  
+  /// Waits for the test to fulfill a set of expectations within a specified time.
+  /// - Parameters:
+  ///   - expectations: An array of async expectations that must be fulfilled.
+  ///   - timeout: The number of seconds within which all expectations must be fulfilled.
+  @MainActor
+  public func waitForExpectations(_ expectations: [AsyncExpectation],
+                                  timeout: Double = 1.0,
+                                  file: StaticString = #filePath,
+                                  line: UInt = #line) async {
+    await AsyncExpectation.waitForExpectations(expectations,
+                                               timeout: timeout,
+                                               file: file,
+                                               line: line)
+  }
+  
+}

--- a/Tests/AsyncAlgorithmsTests/AsyncExpectation.swift
+++ b/Tests/AsyncAlgorithmsTests/AsyncExpectation.swift
@@ -1,0 +1,129 @@
+import Foundation
+import XCTest
+
+extension Task where Success == Never, Failure == Never {
+  static func sleep(seconds: Double) async throws {
+    let nanoseconds = UInt64(seconds * Double(NSEC_PER_SEC))
+    try await Task.sleep(nanoseconds: nanoseconds)
+  }
+}
+
+public actor AsyncExpectation {
+  enum State {
+    case pending
+    case fulfilled
+    case timedOut
+  }
+  public typealias AsyncExpectationContinuation = CheckedContinuation<Void, Error>
+  public let expectationDescription: String
+  public let isInverted: Bool
+  public let expectedFulfillmentCount: Int
+  
+  private var fulfillmentCount: Int = 0
+  private var continuation: AsyncExpectationContinuation?
+  private var state: State = .pending
+  
+  public init(description: String,
+              isInverted: Bool = false,
+              expectedFulfillmentCount: Int = 1) {
+    expectationDescription = description
+    self.isInverted = isInverted
+    self.expectedFulfillmentCount = expectedFulfillmentCount
+  }
+  
+  public static func expectation(description: String,
+                                 isInverted: Bool = false,
+                                 expectedFulfillmentCount: Int = 1) -> AsyncExpectation {
+    AsyncExpectation(description: description,
+                     isInverted: isInverted,
+                     expectedFulfillmentCount: expectedFulfillmentCount)
+  }
+  
+  public func fulfill(file: StaticString = #filePath, line: UInt = #line) {
+    guard state != .fulfilled else { return }
+    
+    guard !isInverted else {
+      XCTFail("Inverted expectation fulfilled: \(expectationDescription)", file: file, line: line)
+      finish()
+      return
+    }
+    
+    fulfillmentCount += 1
+    if fulfillmentCount == expectedFulfillmentCount {
+      state = .fulfilled
+      finish()
+    }
+  }
+  
+  @MainActor
+  public static func waitForExpectations(_ expectations: [AsyncExpectation],
+                                         timeout: Double = 1.0,
+                                         file: StaticString = #filePath,
+                                         line: UInt = #line) async throws {
+    guard !expectations.isEmpty else { return }
+    
+    // check if all expectations are already satisfied and skip sleeping
+    var count = 0
+    for exp in expectations {
+      if await exp.state == .fulfilled {
+        count += 1
+      }
+    }
+    if count == expectations.count {
+      return
+    }
+    
+    let timeout = Task {
+      try await Task.sleep(seconds: timeout)
+      for exp in expectations {
+        await exp.timeOut(file: file, line: line)
+      }
+    }
+    
+    await withThrowingTaskGroup(of: Void.self) { group in
+      for exp in expectations {
+        group.addTask {
+          try await exp.wait()
+        }
+      }
+    }
+    
+    timeout.cancel()
+  }
+  
+  private func wait() async throws {
+    try await withTaskCancellationHandler(handler: {
+      Task {
+        await cancel()
+      }
+    }, operation: {
+      if state == .fulfilled {
+        return
+      } else {
+        return try await withCheckedThrowingContinuation { (continuation: AsyncExpectationContinuation) in
+          self.continuation = continuation
+        }
+      }
+    })
+  }
+  
+  private func timeOut(file: StaticString = #filePath,
+                       line: UInt = #line) async {
+    if state != .fulfilled && !isInverted {
+      state = .timedOut
+      XCTFail("Expectation timed out: \(expectationDescription)", file: file, line: line)
+    }
+    finish()
+  }
+  
+  private func cancel() {
+    continuation?.resume(throwing: CancellationError())
+    continuation = nil
+  }
+  
+  private func finish() {
+    continuation?.resume(returning: ())
+    continuation = nil
+  }
+  
+}

--- a/Tests/AsyncAlgorithmsTests/TestChannel.swift
+++ b/Tests/AsyncAlgorithmsTests/TestChannel.swift
@@ -89,114 +89,110 @@ final class TestChannel: XCTestCase {
     wait(for: [sendImmediatelyResumes], timeout: 1.0)
   }
 
-  func test_asyncChannel_ends_alls_iterators_and_discards_additional_sent_values_when_finish_is_called() async {
+  func test_asyncChannel_ends_alls_iterators_and_discards_additional_sent_values_when_finish_is_called() async throws {
     let channel = AsyncChannel<String>()
     let complete = ManagedCriticalState(false)
-    let finished = expectation(description: "finished")
+    let finished = AsyncExpectation.expectation(description: "finished")
 
     Task {
       channel.finish()
       complete.withCriticalRegion { $0 = true }
-      finished.fulfill()
+      await finished.fulfill()
     }
 
     let valueFromConsumer1 = ManagedCriticalState<String?>(nil)
     let valueFromConsumer2 = ManagedCriticalState<String?>(nil)
 
-    let received = expectation(description: "received")
-    received.expectedFulfillmentCount = 2
+    let received = AsyncExpectation.expectation(description: "received", expectedFulfillmentCount: 2)
 
-    let pastEnd = expectation(description: "pastEnd")
-    pastEnd.expectedFulfillmentCount = 2
+    let pastEnd = AsyncExpectation.expectation(description: "pastEnd", expectedFulfillmentCount: 2)
 
     Task {
       var iterator = channel.makeAsyncIterator()
       let ending = await iterator.next()
       valueFromConsumer1.withCriticalRegion { $0 = ending }
-      received.fulfill()
+      await received.fulfill()
       let item = await iterator.next()
       XCTAssertNil(item)
-      pastEnd.fulfill()
+      await pastEnd.fulfill()
     }
 
     Task {
       var iterator = channel.makeAsyncIterator()
       let ending = await iterator.next()
       valueFromConsumer2.withCriticalRegion { $0 = ending }
-      received.fulfill()
+      await received.fulfill()
       let item = await iterator.next()
       XCTAssertNil(item)
-      pastEnd.fulfill()
+      await pastEnd.fulfill()
     }
     
-    wait(for: [finished, received], timeout: 1.0)
+    try await AsyncExpectation.waitForExpectations([finished, received], timeout: 1.0)
 
     XCTAssertTrue(complete.withCriticalRegion { $0 })
     XCTAssertEqual(valueFromConsumer1.withCriticalRegion { $0 }, nil)
     XCTAssertEqual(valueFromConsumer2.withCriticalRegion { $0 }, nil)
 
-    wait(for: [pastEnd], timeout: 1.0)
-    let additionalSend = expectation(description: "additional send")
+    try await AsyncExpectation.waitForExpectations([pastEnd], timeout: 1.0)
+    let additionalSend = AsyncExpectation.expectation(description: "additional send")
     Task {
       await channel.send("test")
-      additionalSend.fulfill()
+      await additionalSend.fulfill()
     }
-    wait(for: [additionalSend], timeout: 1.0)
+    try await AsyncExpectation.waitForExpectations([additionalSend], timeout: 1.0)
   }
-
-  func test_asyncThrowingChannel_ends_alls_iterators_and_discards_additional_sent_values_when_finish_is_called() async {
+  
+  func test_asyncThrowingChannel_ends_alls_iterators_and_discards_additional_sent_values_when_finish_is_called() async throws {
     let channel = AsyncThrowingChannel<String, Error>()
     let complete = ManagedCriticalState(false)
-    let finished = expectation(description: "finished")
+    let finished = AsyncExpectation.expectation(description: "finished")
     
     Task {
       channel.finish()
       complete.withCriticalRegion { $0 = true }
-      finished.fulfill()
+      await finished.fulfill()
     }
 
     let valueFromConsumer1 = ManagedCriticalState<String?>(nil)
     let valueFromConsumer2 = ManagedCriticalState<String?>(nil)
 
-    let received = expectation(description: "received")
-    received.expectedFulfillmentCount = 2
+    let received = AsyncExpectation.expectation(description: "received", expectedFulfillmentCount: 2)
 
-    let pastEnd = expectation(description: "pastEnd")
-    pastEnd.expectedFulfillmentCount = 2
+    let pastEnd = AsyncExpectation.expectation(description: "pastEnd", expectedFulfillmentCount: 2)
 
     Task {
       var iterator = channel.makeAsyncIterator()
       let ending = try await iterator.next()
       valueFromConsumer1.withCriticalRegion { $0 = ending }
-      received.fulfill()
+      await received.fulfill()
       let item = try await iterator.next()
       XCTAssertNil(item)
-      pastEnd.fulfill()
+      await pastEnd.fulfill()
     }
 
     Task {
       var iterator = channel.makeAsyncIterator()
       let ending = try await iterator.next()
       valueFromConsumer2.withCriticalRegion { $0 = ending }
-      received.fulfill()
+      await received.fulfill()
       let item = try await iterator.next()
       XCTAssertNil(item)
-      pastEnd.fulfill()
+      await pastEnd.fulfill()
     }
-
-    wait(for: [finished, received], timeout: 1.0)
+    
+    try await AsyncExpectation.waitForExpectations([finished, received], timeout: 1.0)
 
     XCTAssertTrue(complete.withCriticalRegion { $0 })
     XCTAssertEqual(valueFromConsumer1.withCriticalRegion { $0 }, nil)
     XCTAssertEqual(valueFromConsumer2.withCriticalRegion { $0 }, nil)
 
-    wait(for: [pastEnd], timeout: 1.0)
-    let additionalSend = expectation(description: "additional send")
+    try await AsyncExpectation.waitForExpectations([pastEnd], timeout: 1.0)
+    let additionalSend = AsyncExpectation.expectation(description: "additional send")
     Task {
       await channel.send("test")
-      additionalSend.fulfill()
+      await additionalSend.fulfill()
     }
-    wait(for: [additionalSend], timeout: 1.0)
+    try await AsyncExpectation.waitForExpectations([additionalSend], timeout: 1.0)
   }
   
   func test_asyncChannel_ends_iterator_when_task_is_cancelled() async {
@@ -207,10 +203,15 @@ final class TestChannel: XCTestCase {
       ready.fulfill()
       return await iterator.next()
     }
-    wait(for: [ready], timeout: 1.0)
+    await waitForExpectations(timeout: 1.0)
     task.cancel()
-    let value = await task.value
-    XCTAssertNil(value)
+    let done = expectation(description: "done")
+    Task {
+      let value = await task.value
+      XCTAssertNil(value)
+      done.fulfill()
+    }
+    await waitForExpectations(timeout: 1.0)
   }
 
   func test_asyncThrowingChannel_ends_iterator_when_task_is_cancelled() async throws {
@@ -221,39 +222,50 @@ final class TestChannel: XCTestCase {
       ready.fulfill()
       return try await iterator.next()
     }
-    wait(for: [ready], timeout: 1.0)
+    await waitForExpectations(timeout: 1.0)
     task.cancel()
-    let value = try await task.value
-    XCTAssertNil(value)
+    let done = expectation(description: "done")
+    Task {
+      let value = try await task.value
+      XCTAssertNil(value)
+      done.fulfill()
+    }
+    await waitForExpectations(timeout: 1.0)
   }
   
   func test_asyncChannel_resumes_send_when_task_is_cancelled() async {
     let channel = AsyncChannel<Int>()
     let notYetDone = expectation(description: "not yet done")
     notYetDone.isInverted = true
-    let done = expectation(description: "done")
     let task = Task {
       await channel.send(1)
       notYetDone.fulfill()
-      done.fulfill()
     }
-    wait(for: [notYetDone], timeout: 0.1)
+    await waitForExpectations(timeout: 0.1)
     task.cancel()
-    wait(for: [done], timeout: 1.0)
+    let done = expectation(description: "done")
+    Task {
+        _ = await task.value
+        done.fulfill()
+    }
+    await waitForExpectations(timeout: 1.0)
   }
   
   func test_asyncThrowingChannel_resumes_send_when_task_is_cancelled() async {
     let channel = AsyncThrowingChannel<Int, Error>()
     let notYetDone = expectation(description: "not yet done")
     notYetDone.isInverted = true
-    let done = expectation(description: "done")
     let task = Task {
       await channel.send(1)
       notYetDone.fulfill()
-      done.fulfill()
     }
-    wait(for: [notYetDone], timeout: 0.1)
+    await waitForExpectations(timeout: 0.1)
     task.cancel()
-    wait(for: [done], timeout: 1.0)
+    let done = expectation(description: "done")
+    Task {
+        _ = await task.value
+        done.fulfill()
+    }
+    await waitForExpectations(timeout: 1.0)
   }
 }


### PR DESCRIPTION
The original expectations features in XCTests are not fully compatible with iOS. The tests for AsyncChannel pass with macOS but not iOS.

This PR includes a new type called AsyncExpectation which provides an async version of `XCTestExpectation` which has the features used in these tests. Migrating to this type required only small changes. [AsyncTesting](https://github.com/brennanMKE/AsyncTesting) is a new package with this support for testing which includes tests for this functionality.

With these changes the tests pass quickly on macOS and iOS.