### PR TITLE
[Merge] optimize tasks creation and remove sendable constraint

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,9 +16,14 @@ let package = Package(
     .library(name: "_CAsyncSequenceValidationSupport", type: .static, targets: ["AsyncSequenceValidation"]),
     .library(name: "AsyncAlgorithms_XCTest", targets: ["AsyncAlgorithms_XCTest"]),
   ],
-  dependencies: [],
+  dependencies: [
+    .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.0.3"))
+  ],
   targets: [
-    .target(name: "AsyncAlgorithms"),
+    .target(
+      name: "AsyncAlgorithms",
+      dependencies: [.product(name: "Collections", package: "swift-collections")]
+    ),
     .target(
       name: "AsyncSequenceValidation",
       dependencies: ["_CAsyncSequenceValidationSupport", "AsyncAlgorithms"]),

--- a/Sources/AsyncAlgorithms/AsyncChannel.swift
+++ b/Sources/AsyncAlgorithms/AsyncChannel.swift
@@ -28,7 +28,7 @@ public final class AsyncChannel<Element: Sendable>: AsyncSequence, Sendable {
     init(_ channel: AsyncChannel<Element>) {
       self.channel = channel
     }
-    
+
     /// Await the next sent element or finish.
     public mutating func next() async -> Element? {
       guard active else {
@@ -116,7 +116,7 @@ public final class AsyncChannel<Element: Sendable>: AsyncSequence, Sendable {
   
   /// Create a new `AsyncChannel` given an element type.
   public init(element elementType: Element.Type = Element.self) { }
-  
+
   func establish() -> Int {
     state.withCriticalRegion { state in
       defer { state.generation &+= 1 }
@@ -152,7 +152,7 @@ public final class AsyncChannel<Element: Sendable>: AsyncSequence, Sendable {
           }
           return UnsafeResumption(continuation: send, success: continuation)
         case .awaiting(var nexts):
-          if nexts.update(with: Awaiting(generation: generation, continuation: continuation)) != nil {
+            if nexts.update(with: Awaiting(generation: generation, continuation: continuation)) != nil {
             nexts.remove(Awaiting(placeholder: generation))
             cancelled = true
           }

--- a/Sources/AsyncAlgorithms/AsyncMerge3Sequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncMerge3Sequence.swift
@@ -10,14 +10,12 @@
 //===----------------------------------------------------------------------===//
 
 /// Creates an asynchronous sequence of elements from three underlying asynchronous sequences
-public func merge<Base1: AsyncSequence, Base2: AsyncSequence, Base3: AsyncSequence>(_ base1: Base1, _ base2: Base2, _ base3: Base3) -> AsyncMerge3Sequence<Base1, Base2, Base3>
-where
-  Base1.Element == Base2.Element,
-  Base2.Element == Base3.Element,
-  Base1: Sendable, Base2: Sendable, Base3: Sendable,
-  Base1.Element: Sendable,
-  Base1.AsyncIterator: Sendable, Base2.AsyncIterator: Sendable, Base3.AsyncIterator: Sendable {
-  return AsyncMerge3Sequence(base1, base2, base3)
+public func merge<Base1: AsyncSequence, Base2: AsyncSequence, Base3: AsyncSequence>(
+  _ base1: Base1,
+  _ base2: Base2,
+  _ base3: Base3
+) -> AsyncMerge3Sequence<Base1, Base2, Base3> {
+  AsyncMerge3Sequence(base1, base2, base3)
 }
 
 /// An asynchronous sequence of elements from three underlying asynchronous sequences
@@ -25,260 +23,51 @@ where
 /// In a `AsyncMerge3Sequence` instance, the *i*th element is the *i*th element
 /// resolved in sequential order out of the two underlying asynchronous sequences.
 /// Use the `merge(_:_:_:)` function to create an `AsyncMerge3Sequence`.
-public struct AsyncMerge3Sequence<Base1: AsyncSequence, Base2: AsyncSequence, Base3: AsyncSequence>: AsyncSequence, Sendable
-where
-  Base1.Element == Base2.Element,
-  Base2.Element == Base3.Element,
-  Base1: Sendable, Base2: Sendable, Base3: Sendable,
-  Base1.Element: Sendable,
-  Base1.AsyncIterator: Sendable, Base2.AsyncIterator: Sendable, Base3.AsyncIterator: Sendable {
+public struct AsyncMerge3Sequence<Base1: AsyncSequence, Base2: AsyncSequence, Base3: AsyncSequence>: AsyncSequence
+where Base1.Element == Base2.Element, Base3.Element == Base2.Element {
   public typealias Element = Base1.Element
-  /// An iterator for `AsyncMerge3Sequence`
-  public struct Iterator: AsyncIteratorProtocol, Sendable {
-    enum Partial: @unchecked Sendable {
-      case first(Result<Element?, Error>, Base1.AsyncIterator)
-      case second(Result<Element?, Error>, Base2.AsyncIterator)
-      case third(Result<Element?, Error>, Base3.AsyncIterator)
-    }
-    
-    var state: (PartialIteration<Base1.AsyncIterator, Partial>, PartialIteration<Base2.AsyncIterator, Partial>, PartialIteration<Base3.AsyncIterator, Partial>)
-    
-    init(_ iterator1: Base1.AsyncIterator, _ iterator2: Base2.AsyncIterator, _ iterator3: Base3.AsyncIterator) {
-      state = (.idle(iterator1), .idle(iterator2), .idle(iterator3))
-    }
-    
-    mutating func apply(_ task1: Task<Partial, Never>?, _ task2: Task<Partial, Never>?, _ task3: Task<Partial, Never>?) async rethrows -> Element? {
-      switch await Task.select([task1, task2, task3].compactMap { $0 }).value {
-      case .first(let result, let iterator):
-        do {
-          guard let value = try state.0.resolve(result, iterator) else {
-            return try await next()
-          }
-          return value
-        } catch {
-          state.1.cancel()
-          state.2.cancel()
-          throw error
-        }
-      case .second(let result, let iterator):
-        do {
-          guard let value = try state.1.resolve(result, iterator) else {
-            return try await next()
-          }
-          return value
-        } catch {
-          state.0.cancel()
-          state.2.cancel()
-          throw error
-        }
-      case .third(let result, let iterator):
-        do {
-          guard let value = try state.2.resolve(result, iterator) else {
-            return try await next()
-          }
-          return value
-        } catch {
-          state.0.cancel()
-          state.1.cancel()
-          throw error
-        }
-      }
-    }
-    
-    func first(_ iterator1: Base1.AsyncIterator) -> Task<Partial, Never> {
-      Task {
-        var iter = iterator1
-        do {
-          let value = try await iter.next()
-          return .first(.success(value), iter)
-        } catch {
-          return .first(.failure(error), iter)
-        }
-      }
-    }
-    
-    func second(_ iterator2: Base2.AsyncIterator) -> Task<Partial, Never> {
-      Task {
-        var iter = iterator2
-        do {
-          let value = try await iter.next()
-          return .second(.success(value), iter)
-        } catch {
-          return .second(.failure(error), iter)
-        }
-      }
-    }
-    
-    func third(_ iterator3: Base3.AsyncIterator) -> Task<Partial, Never> {
-      Task {
-        var iter = iterator3
-        do {
-          let value = try await iter.next()
-          return .third(.success(value), iter)
-        } catch {
-          return .third(.failure(error), iter)
-        }
-      }
-    }
-    
-    public mutating func next() async rethrows -> Element? {
-      // state must have either all terminal or at least 1 idle iterator
-      // state may not have a saturation of pending tasks
-      switch state {
-      // three idle
-      case (.idle(let iterator1), .idle(let iterator2), .idle(let iterator3)):
-        let task1 = first(iterator1)
-        let task2 = second(iterator2)
-        let task3 = third(iterator3)
-        state = (.pending(task1), .pending(task2), .pending(task3))
-        return try await apply(task1, task2, task3)
-      // two idle
-      case (.idle(let iterator1), .idle(let iterator2), .pending(let task3)):
-        let task1 = first(iterator1)
-        let task2 = second(iterator2)
-        state = (.pending(task1), .pending(task2), .pending(task3))
-        return try await apply(task1, task2, task3)
-      case (.idle(let iterator1), .pending(let task2), .idle(let iterator3)):
-        let task1 = first(iterator1)
-        let task3 = third(iterator3)
-        state = (.pending(task1), .pending(task2), .pending(task3))
-        return try await apply(task1, task2, task3)
-      case (.pending(let task1), .idle(let iterator2), .idle(let iterator3)):
-        let task2 = second(iterator2)
-        let task3 = third(iterator3)
-        state = (.pending(task1), .pending(task2), .pending(task3))
-        return try await apply(task1, task2, task3)
-        
-      // 1 idle
-      case (.idle(let iterator1), .pending(let task2), .pending(let task3)):
-        let task1 = first(iterator1)
-        state = (.pending(task1), .pending(task2), .pending(task3))
-        return try await apply(task1, task2, task3)
-      case (.pending(let task1), .idle(let iterator2), .pending(let task3)):
-        let task2 = second(iterator2)
-        state = (.pending(task1), .pending(task2), .pending(task3))
-        return try await apply(task1, task2, task3)
-      case (.pending(let task1), .pending(let task2), .idle(let iterator3)):
-        let task3 = third(iterator3)
-        state = (.pending(task1), .pending(task2), .pending(task3))
-        return try await apply(task1, task2, task3)
-        
-      // terminal degradations
-      // 1 terminal
-      case (.terminal, .idle(let iterator2), .idle(let iterator3)):
-        let task2 = second(iterator2)
-        let task3 = third(iterator3)
-        state = (.terminal, .pending(task2), .pending(task3))
-        return try await apply(nil, task2, task3)
-      case (.terminal, .idle(let iterator2), .pending(let task3)):
-        let task2 = second(iterator2)
-        state = (.terminal, .pending(task2), .pending(task3))
-        return try await apply(nil, task2, task3)
-      case (.terminal, .pending(let task2), .idle(let iterator3)):
-        let task3 = third(iterator3)
-        state = (.terminal, .pending(task2), .pending(task3))
-        return try await apply(nil, task2, task3)
-      case (.idle(let iterator1), .terminal, .idle(let iterator3)):
-        let task1 = first(iterator1)
-        let task3 = third(iterator3)
-        state = (.pending(task1), .terminal, .pending(task3))
-        return try await apply(task1, nil, task3)
-      case (.idle(let iterator1), .terminal, .pending(let task3)):
-        let task1 = first(iterator1)
-        state = (.pending(task1), .terminal, .pending(task3))
-        return try await apply(task1, nil, task3)
-      case (.pending(let task1), .terminal, .idle(let iterator3)):
-        let task3 = third(iterator3)
-        state = (.pending(task1), .terminal, .pending(task3))
-        return try await apply(task1, nil, task3)
-      case (.idle(let iterator1), .idle(let iterator2), .terminal):
-        let task1 = first(iterator1)
-        let task2 = second(iterator2)
-        state = (.pending(task1), .pending(task2), .terminal)
-        return try await apply(task1, task2, nil)
-      case (.idle(let iterator1), .pending(let task2), .terminal):
-        let task1 = first(iterator1)
-        state = (.pending(task1), .pending(task2), .terminal)
-        return try await apply(task1, task2, nil)
-      case (.pending(let task1), .idle(let iterator2), .terminal):
-        let task2 = second(iterator2)
-        state = (.pending(task1), .pending(task2), .terminal)
-        return try await apply(task1, task2, nil)
-        
-      // 2 terminal
-      // these can be permuted in place since they don't need to run two or more tasks at once
-      case (.terminal, .terminal, .idle(var iterator3)):
-        do {
-          if let value = try await iterator3.next() {
-            state = (.terminal, .terminal, .idle(iterator3))
-            return value
-          } else {
-            state = (.terminal, .terminal, .terminal)
-            return nil
-          }
-        } catch {
-          state = (.terminal, .terminal, .terminal)
-          throw error
-        }
-      case (.terminal, .idle(var iterator2), .terminal):
-        do {
-          if let value = try await iterator2.next() {
-            state = (.terminal, .idle(iterator2), .terminal)
-            return value
-          } else {
-            state = (.terminal, .terminal, .terminal)
-            return nil
-          }
-        } catch {
-          state = (.terminal, .terminal, .terminal)
-          throw error
-        }
-      case (.idle(var iterator1), .terminal, .terminal):
-        do {
-          if let value = try await iterator1.next() {
-            state = (.idle(iterator1), .terminal, .terminal)
-            return value
-          } else {
-            state = (.terminal, .terminal, .terminal)
-            return nil
-          }
-        } catch {
-          state = (.terminal, .terminal, .terminal)
-          throw error
-        }
-      // 3 terminal
-      case (.terminal, .terminal, .terminal):
-        return nil
-      // partials
-      case (.pending(let task1), .pending(let task2), .pending(let task3)):
-        return try await apply(task1, task2, task3)
-      case (.pending(let task1), .pending(let task2), .terminal):
-        return try await apply(task1, task2, nil)
-      case (.pending(let task1), .terminal, .pending(let task3)):
-        return try await apply(task1, nil, task3)
-      case (.terminal, .pending(let task2), .pending(let task3)):
-        return try await apply(nil, task2, task3)
-      case (.pending(let task1), .terminal, .terminal):
-        return try await apply(task1, nil, nil)
-      case (.terminal, .pending(let task2), .terminal):
-        return try await apply(nil, task2, nil)
-      case (.terminal, .terminal, .pending(let task3)):
-        return try await apply(nil, nil, task3)
-      }
-    }
-  }
-    
+  public typealias AsyncIterator = Iterator
+
   let base1: Base1
   let base2: Base2
   let base3: Base3
 
-  init(_ base1: Base1, _ base2: Base2, _ base3: Base3) {
+  public init(_ base1: Base1, _ base2: Base2,  _ base3: Base3) {
     self.base1 = base1
     self.base2 = base2
     self.base3 = base3
   }
 
   public func makeAsyncIterator() -> Iterator {
-    return Iterator(base1.makeAsyncIterator(), base2.makeAsyncIterator(), base3.makeAsyncIterator())
+    Iterator(
+      base1: self.base1,
+      base2: self.base2,
+      base3: self.base3
+    )
+  }
+
+  public struct Iterator: AsyncIteratorProtocol {
+    let mergeStateMachine: MergeStateMachine<Element>
+
+    init(base1: Base1, base2: Base2, base3: Base3) {
+      self.mergeStateMachine = MergeStateMachine(
+        base1,
+        base2,
+        base3
+      )
+    }
+
+    public mutating func next() async rethrows -> Element? {
+      let mergedElement = await self.mergeStateMachine.next()
+      switch mergedElement {
+        case .element(let result):
+          return try result._rethrowGet()
+        case .termination:
+          return nil
+      }
+    }
   }
 }
+
+extension AsyncMerge3Sequence: Sendable where Base1: Sendable, Base2: Sendable, Base3: Sendable {}
+extension AsyncMerge3Sequence.Iterator: Sendable where Base1: Sendable, Base2: Sendable, Base3: Sendable {}

--- a/Sources/AsyncAlgorithms/AsyncMergeSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncMergeSequence.swift
@@ -9,46 +9,40 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Creates an asynchronous sequence of elements from two underlying asynchronous sequences
-public func merge<Base1: AsyncSequence, Base2: AsyncSequence>(
-  _ base1: Base1,
-  _ base2: Base2
-) -> AsyncMerge2Sequence<Base1, Base2>{
-  AsyncMerge2Sequence(base1, base2)
+/// Creates an asynchronous sequence of elements from many underlying asynchronous sequences
+public func merge<Base: AsyncSequence>(
+  _ bases: Base...
+) -> AsyncMergeSequence<Base>{
+  AsyncMergeSequence(bases)
 }
 
-/// An asynchronous sequence of elements from two underlying asynchronous sequences
+/// An asynchronous sequence of elements from many underlying asynchronous sequences
 ///
-/// In a `AsyncMerge2Sequence` instance, the *i*th element is the *i*th element
+/// In a `AsyncMergeSequence` instance, the *i*th element is the *i*th element
 /// resolved in sequential order out of the two underlying asynchronous sequences.
-/// Use the `merge(_:_:)` function to create an `AsyncMerge2Sequence`.
-public struct AsyncMerge2Sequence<Base1: AsyncSequence, Base2: AsyncSequence>: AsyncSequence
-where Base1.Element == Base2.Element {
-  public typealias Element = Base1.Element
+/// Use the `merge(...)` function to create an `AsyncMergeSequence`.
+public struct AsyncMergeSequence<Base: AsyncSequence>: AsyncSequence {
+  public typealias Element = Base.Element
   public typealias AsyncIterator = Iterator
 
-  let base1: Base1
-  let base2: Base2
+  let bases: [Base]
 
-  public init(_ base1: Base1, _ base2: Base2) {
-    self.base1 = base1
-    self.base2 = base2
+  public init(_ bases: [Base]) {
+    self.bases = bases
   }
 
   public func makeAsyncIterator() -> Iterator {
     Iterator(
-      base1: self.base1,
-      base2: self.base2
+      bases: self.bases
     )
   }
 
   public struct Iterator: AsyncIteratorProtocol {
     let mergeStateMachine: MergeStateMachine<Element>
 
-    init(base1: Base1, base2: Base2) {
+    init(bases: [Base]) {
       self.mergeStateMachine = MergeStateMachine(
-        base1,
-        base2
+        bases
       )
     }
 
@@ -64,5 +58,5 @@ where Base1.Element == Base2.Element {
   }
 }
 
-extension AsyncMerge2Sequence: Sendable where Base1: Sendable, Base2: Sendable {}
-extension AsyncMerge2Sequence.Iterator: Sendable where Base1: Sendable, Base2: Sendable {}
+extension AsyncMergeSequence: Sendable where Base: Sendable {}
+extension AsyncMergeSequence.Iterator: Sendable where Base: Sendable {}

--- a/Sources/AsyncAlgorithms/MergeStateMachine.swift
+++ b/Sources/AsyncAlgorithms/MergeStateMachine.swift
@@ -1,0 +1,272 @@
+//
+//  MergeStateMachine.swift
+//  
+//
+//  Created by Thibault Wittemberg on 08/09/2022.
+//
+
+import DequeModule
+
+struct MergeStateMachine<Element>: Sendable {
+  enum MergedElement {
+    case element(Result<Element, Error>)
+    case termination
+  }
+
+  enum BufferState {
+    case idle
+    case queued(Deque<MergedElement>)
+    case awaiting(UnsafeContinuation<MergedElement, Never>)
+    case closed
+  }
+
+  struct State {
+    var buffer: BufferState
+    var basesToTerminate: Int
+  }
+
+  struct OnNextDecision {
+    let continuation: UnsafeContinuation<MergedElement, Never>
+    let mergedElement: MergedElement
+  }
+
+  let requestNextRegulatedElements: @Sendable () -> Void
+  let state: ManagedCriticalState<State>
+  let task: Task<Void, Never>
+
+  init<Base1: AsyncSequence, Base2: AsyncSequence>(
+    _ base1: Base1,
+    terminatesOnNil base1TerminatesOnNil: Bool = false,
+    _ base2: Base2,
+    terminatesOnNil base2TerminatesOnNil: Bool = false
+  ) where Base1.Element == Element, Base2.Element == Element {
+    self.state = ManagedCriticalState(State(buffer: .idle, basesToTerminate: 2))
+
+    let regulator1 = Regulator(base1, onNextRegulatedElement: { [state] in Self.onNextRegulatedElement($0, state: state) })
+    let regulator2 = Regulator(base2, onNextRegulatedElement: { [state] in Self.onNextRegulatedElement($0, state: state) })
+
+    self.requestNextRegulatedElements = {
+      regulator1.requestNextRegulatedElement()
+      regulator2.requestNextRegulatedElement()
+    }
+
+    self.task = Task {
+      await withTaskGroup(of: Void.self) { group in
+        group.addTask {
+          await regulator1.iterate(terminatesOnNil: base1TerminatesOnNil)
+        }
+
+        group.addTask {
+          await regulator2.iterate(terminatesOnNil: base2TerminatesOnNil)
+        }
+      }
+    }
+  }
+
+  init<Base1: AsyncSequence, Base2: AsyncSequence, Base3: AsyncSequence>(
+    _ base1: Base1,
+    terminatesOnNil base1TerminatesOnNil: Bool = false,
+    _ base2: Base2,
+    terminatesOnNil base2TerminatesOnNil: Bool = false,
+    _ base3: Base3,
+    terminatesOnNil base3TerminatesOnNil: Bool = false
+  ) where Base1.Element == Element, Base2.Element == Element, Base3.Element == Base1.Element {
+    self.state = ManagedCriticalState(State(buffer: .idle, basesToTerminate: 3))
+
+    let regulator1 = Regulator(base1, onNextRegulatedElement: { [state] in Self.onNextRegulatedElement($0, state: state) })
+    let regulator2 = Regulator(base2, onNextRegulatedElement: { [state] in Self.onNextRegulatedElement($0, state: state) })
+    let regulator3 = Regulator(base3, onNextRegulatedElement: { [state] in Self.onNextRegulatedElement($0, state: state) })
+
+    self.requestNextRegulatedElements = {
+      regulator1.requestNextRegulatedElement()
+      regulator2.requestNextRegulatedElement()
+      regulator3.requestNextRegulatedElement()
+    }
+
+    self.task = Task {
+      await withTaskGroup(of: Void.self) { group in
+        group.addTask {
+          await regulator1.iterate(terminatesOnNil: base1TerminatesOnNil)
+        }
+
+        group.addTask {
+          await regulator2.iterate(terminatesOnNil: base2TerminatesOnNil)
+        }
+
+        group.addTask {
+          await regulator3.iterate(terminatesOnNil: base3TerminatesOnNil)
+        }
+      }
+    }
+  }
+
+  init<Base: AsyncSequence>(
+    _ bases: [Base]
+  ) where Base.Element == Element {
+    self.state = ManagedCriticalState(State(buffer: .idle, basesToTerminate: bases.count))
+
+    var regulators = [Regulator<Base>]()
+
+    for base in bases {
+      let regulator = Regulator<Base>(base, onNextRegulatedElement: { [state] in Self.onNextRegulatedElement($0, state: state) })
+      regulators.append(regulator)
+    }
+
+    let immutableRegulators = regulators
+    self.requestNextRegulatedElements = {
+      for regulator in immutableRegulators {
+        regulator.requestNextRegulatedElement()
+      }
+    }
+
+    self.task = Task {
+      await withTaskGroup(of: Void.self) { group in
+        for regulators in immutableRegulators {
+          group.addTask {
+            await regulators.iterate(terminatesOnNil: false)
+          }
+        }
+      }
+    }
+  }
+
+  @Sendable static func onNextRegulatedElement(_ element: RegulatedElement<Element>, state: ManagedCriticalState<State>) {
+    let decision = state.withCriticalRegion { state -> OnNextDecision? in
+      switch (state.buffer, element) {
+        // when buffer is close
+        case (.closed, _):
+          return nil
+
+        // when buffer is empty and available
+        case (.idle, .termination(let forcedTermination)) where forcedTermination == true:
+          state.basesToTerminate = 0
+          state.buffer = .closed
+          return nil
+        case (.idle, .termination):
+          state.basesToTerminate -= 1
+          if state.basesToTerminate == 0 {
+            state.buffer = .closed
+          } else {
+            state.buffer = .idle
+          }
+          return nil
+        case (.idle, .element(let result)):
+          state.buffer = .queued([.element(result)])
+          return nil
+
+        // when buffer is queued
+        case (.queued(var elements), .termination(let forcedTermination)) where forcedTermination == true:
+          elements.append(.termination)
+          state.buffer = .queued(elements)
+          return nil
+        case (.queued(var elements), .termination):
+          state.basesToTerminate -= 1
+          if state.basesToTerminate == 0 {
+            elements.append(.termination)
+            state.buffer = .queued(elements)
+          }
+          return nil
+        case (.queued(var elements), .element(let result)):
+          elements.append(.element(result))
+          state.buffer = .queued(elements)
+          return nil
+
+        // when buffer is awaiting for base values
+        case (.awaiting(let continuation), .termination(let forcedTermination)) where forcedTermination == true:
+          state.basesToTerminate = 0
+          state.buffer = .closed
+          return OnNextDecision(continuation: continuation, mergedElement: .termination)
+        case (.awaiting(let continuation), .termination):
+          state.basesToTerminate -= 1
+          if state.basesToTerminate == 0 {
+            state.buffer = .closed
+            return OnNextDecision(continuation: continuation, mergedElement: .termination)
+          } else {
+            state.buffer = .awaiting(continuation)
+            return nil
+          }
+        case (.awaiting(let continuation), .element(.success(let element))):
+          state.buffer = .idle
+          return OnNextDecision(continuation: continuation, mergedElement: .element(.success(element)))
+        case (.awaiting(let continuation), .element(.failure(let error))):
+          state.buffer = .closed
+          return OnNextDecision(continuation: continuation, mergedElement: .element(.failure(error)))
+      }
+    }
+
+    if let decision = decision {
+      decision.continuation.resume(returning: decision.mergedElement)
+    }
+  }
+
+  @Sendable func unsuspendAndClearOnCancel() {
+    let continuation = self.state.withCriticalRegion { state -> UnsafeContinuation<MergedElement, Never>? in
+      switch state.buffer {
+        case .awaiting(let continuation):
+          state.basesToTerminate = 0
+          state.buffer = .closed
+          return continuation
+        default:
+          state.basesToTerminate = 0
+          state.buffer = .closed
+          return nil
+      }
+    }
+
+    continuation?.resume(returning: .termination)
+    self.task.cancel()
+  }
+
+  func next() async -> MergedElement {
+    await withTaskCancellationHandler {
+      self.unsuspendAndClearOnCancel()
+    } operation: {
+      self.requestNextRegulatedElements()
+
+      let mergedElement = await withUnsafeContinuation { (continuation: UnsafeContinuation<MergedElement, Never>) in
+        let decision = self.state.withCriticalRegion { state -> OnNextDecision? in
+          switch state.buffer {
+            case .closed:
+              return OnNextDecision(continuation: continuation, mergedElement: .termination)
+            case .idle:
+              state.buffer = .awaiting(continuation)
+              return nil
+            case .queued(var elements):
+              guard let mergedElement = elements.popFirst() else {
+                assertionFailure("The buffer cannot by empty, it should be idle in this case")
+                return OnNextDecision(continuation: continuation, mergedElement: .termination)
+              }
+              switch mergedElement {
+                case .termination:
+                  state.buffer = .closed
+                  return OnNextDecision(continuation: continuation, mergedElement: .termination)
+                case .element(.success(let element)):
+                  if elements.isEmpty {
+                    state.buffer = .idle
+                  } else {
+                    state.buffer = .queued(elements)
+                  }
+                  return OnNextDecision(continuation: continuation, mergedElement: .element(.success(element)))
+                case .element(.failure(let error)):
+                  state.buffer = .closed
+                  return OnNextDecision(continuation: continuation, mergedElement: .element(.failure(error)))
+              }
+            case .awaiting:
+              assertionFailure("The next function cannot be called concurrently")
+              return OnNextDecision(continuation: continuation, mergedElement: .termination)
+          }
+        }
+
+        if let decision = decision {
+          decision.continuation.resume(returning: decision.mergedElement)
+        }
+      }
+
+      if case .termination = mergedElement, case .element(.failure) = mergedElement {
+        self.task.cancel()
+      }
+
+      return mergedElement
+    }
+  }
+}

--- a/Sources/AsyncAlgorithms/Regulator.swift
+++ b/Sources/AsyncAlgorithms/Regulator.swift
@@ -1,0 +1,133 @@
+//
+//  Regulator.swift
+//  
+//
+//  Created by Thibault Wittemberg on 08/09/2022.
+//
+
+enum RegulatedElement<Element> {
+  case termination(forcedTermination: Bool)
+  case element(result: Result<Element, Error>)
+}
+
+struct Regulator<Base: AsyncSequence> {
+  enum State {
+    case idle
+    case suspended(UnsafeContinuation<Bool, Never>)
+    case active
+    case finished
+  }
+
+  enum IterationDecision {
+    case suspend
+    case resume(continuation: UnsafeContinuation<Bool, Never>, shouldExit: Bool)
+  }
+
+  let base: Base
+  let state: ManagedCriticalState<State>
+  let onNextRegulatedElement: @Sendable (RegulatedElement<Base.Element>) -> Void
+
+  init(
+    _ base: Base,
+    onNextRegulatedElement: @Sendable @escaping (RegulatedElement<Base.Element>) -> Void
+  ) {
+    self.base = base
+    self.state = ManagedCriticalState(.idle)
+    self.onNextRegulatedElement = onNextRegulatedElement
+  }
+
+  func unsuspendAndExitOnCancel() {
+    let continuation = state.withCriticalRegion { state -> UnsafeContinuation<Bool, Never>? in
+      switch state {
+        case .suspended(let continuation):
+          state = .finished
+          return continuation
+        default:
+          state = .finished
+          return nil
+      }
+    }
+
+    continuation?.resume(returning: true)
+  }
+
+  func iterate(terminatesOnNil: Bool) async {
+    await withTaskCancellationHandler {
+      self.unsuspendAndExitOnCancel()
+    } operation: {
+
+      var mutableBase = base.makeAsyncIterator()
+
+      do {
+      baseLoop: while true {
+        let shouldExit = await withUnsafeContinuation { (continuation: UnsafeContinuation<Bool, Never>) in
+          let decision = self.state.withCriticalRegion { state -> IterationDecision in
+
+            switch state {
+              case .idle:
+                state = .suspended(continuation)
+                return .suspend
+              case .suspended(let continuation):
+                assertionFailure("Inconsistent state, the base is already suspended")
+                return .resume(continuation: continuation, shouldExit: true)
+              case .active:
+                return .resume(continuation: continuation, shouldExit: false)
+              case .finished:
+                return .resume(continuation: continuation, shouldExit: true)
+            }
+          }
+
+          switch decision {
+            case .suspend:
+              break
+            case .resume(let continuation, let shouldExit):
+              continuation.resume(returning: shouldExit)
+          }
+        }
+
+        if shouldExit {
+          // end the loop ... no more values from this base
+          break baseLoop
+        }
+
+        let element = try await mutableBase.next()
+
+        let regulatedElement = self.state.withCriticalRegion { state -> RegulatedElement<Base.Element> in
+          switch element {
+            case .none:
+              state = .finished
+              return .termination(forcedTermination: terminatesOnNil)
+            case .some(let element):
+              state = .idle
+              return .element(result: .success(element))
+          }
+        }
+
+        self.onNextRegulatedElement(regulatedElement)
+      }
+      } catch {
+        self.state.withCriticalRegion { state in
+          state = .finished
+        }
+        self.onNextRegulatedElement(.element(result: .failure(error)))
+      }
+    }
+  }
+
+  @Sendable func requestNextRegulatedElement() {
+    let continuation = self.state.withCriticalRegion { state -> UnsafeContinuation<Bool, Never>? in
+      switch state {
+        case .suspended(let continuation):
+          state = .active
+          return continuation
+        case .idle:
+          state = .active
+          return nil
+        case .active, .finished:
+          return nil
+      }
+    }
+
+    continuation?.resume(returning: false)
+  }
+}

--- a/Tests/AsyncAlgorithmsTests/Performance/TestThroughput.swift
+++ b/Tests/AsyncAlgorithmsTests/Performance/TestThroughput.swift
@@ -49,6 +49,11 @@ final class TestThroughput: XCTestCase {
       merge($0, $1, $2)
     }
   }
+  func test_merge4() async {
+    await measureSequenceThroughput(firstOutput: 1, secondOutput: 2, thirdOutput: 3, fourthOutput: 4) {
+      merge($0, $1, $2, $3)
+    }
+  }
   func test_removeDuplicates() async {
     await measureSequenceThroughput(source: (1...).async) {
       $0.removeDuplicates()

--- a/Tests/AsyncAlgorithmsTests/TestMerge.swift
+++ b/Tests/AsyncAlgorithmsTests/TestMerge.swift
@@ -84,6 +84,7 @@ final class TestMerge2: XCTestCase {
     } catch {
       XCTAssertEqual(Failure(), error as? Failure)
     }
+
     let pastEnd = try await iterator.next()
 
     XCTAssertNil(pastEnd)


### PR DESCRIPTION
Hi

To follow this discussion https://github.com/apple/swift-async-algorithms/issues/192, here is an attempt to reach several goals:

- minimise the task creation (1 per upstream + 1 main for the group)
- have conditional Sendable conformance for AsyncMergeSequences
- make a MergeStateMachine that can be reused with any number of sequences (preparing the field for variadic params)
- be able to use the same MergeStateMachine in `AsyncChunksOfCountOrSignalSequence`
- improve the performances
- reuse the existing locking mechanism

Some hints about the conception:

- I've introduced the concept of `Regulator`. This is a wrapper around an AsyncSequence that can iterates over it and suspend before calling next until it is resumed by an external entity. I think this is something we can leverage also in `AsyncCombineLatestSequence` where we will also want to avoid creating too much tasks. The Regulator has its own state, not shared with any one else, there is no synchronisation point with the outside.
- The MergeStateMachine is no more specialised with several `AsyncSequence` generic types but only by the `Element` type, which opens the door to variadic params. The MergeStateMachine has its own state also, independent from the upstreams.

Performance wise, this is what I have measured on my M1 Ultra:

Currently:
- Merge2: 150 000 events/s
- Merge3: 115 000 events/s

My PR:
- Merge2: 320 000 events/s
- Merge3: 260 000 events/s

I've added a Merge4 operation in the throughput test just to show that it is now possible to merge any number of AsyncSequence.

There is a significant improvement. @FranzBusch might have even better results with his implementation and perhaps we can improve mine.