### PR TITLE
Deprecation Housekeeping (#206)

### DIFF
--- a/Sources/AsyncAlgorithms/Zip/Zip3Runtime.swift
+++ b/Sources/AsyncAlgorithms/Zip/Zip3Runtime.swift
@@ -26,12 +26,6 @@ where Base1: Sendable, Base1.Element: Sendable, Base2: Sendable, Base2.Element: 
 
   func next() async rethrows -> (Base1.Element, Base2.Element, Base3.Element)? {
     try await withTaskCancellationHandler {
-      let output = self.stateMachine.withCriticalRegion { stateMachine in
-        stateMachine.rootTaskIsCancelled()
-      }
-      // clean the allocated resources and state
-      self.handle(rootTaskIsCancelledOutput: output)
-    } operation: {
       let results = await withUnsafeContinuation { continuation in
         self.stateMachine.withCriticalRegion { stateMachine in
           let output = stateMachine.newDemandFromConsumer(suspendedDemand: continuation)
@@ -61,6 +55,12 @@ where Base1: Sendable, Base1.Element: Sendable, Base2: Sendable, Base2.Element: 
       }
 
       return try (results.0._rethrowGet(), results.1._rethrowGet(), results.2._rethrowGet())
+    } onCancel: {
+      let output = self.stateMachine.withCriticalRegion { stateMachine in
+        stateMachine.rootTaskIsCancelled()
+      }
+      // clean the allocated resources and state
+      self.handle(rootTaskIsCancelledOutput: output)
     }
   }
 


### PR DESCRIPTION
`withTaskCancellationHandler<T>(_:, operation:)` -> `withTaskCancellationHandler<T>(operation:onCancel:)`

One more time for the merges