### PR TITLE
Remove `Sendable` constraint for `AsyncAdjacentPairsSequence`

### DIFF
--- a/Sources/AsyncAlgorithms/AsyncAdjacentPairsSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncAdjacentPairsSequence.swift
@@ -83,5 +83,7 @@ extension AsyncSequence {
   }
 }
 
-extension AsyncAdjacentPairsSequence: Sendable where Base: Sendable, Base.Element: Sendable, Base.AsyncIterator: Sendable { }
-extension AsyncAdjacentPairsSequence.Iterator: Sendable where Base: Sendable, Base.Element: Sendable, Base.AsyncIterator: Sendable { }
+extension AsyncAdjacentPairsSequence: Sendable where Base: Sendable, Base.Element: Sendable { }
+
+@available(*, unavailable)
+extension AsyncAdjacentPairsSequence.Iterator: Sendable { }


### PR DESCRIPTION
# Motivation
We want to remove any `Sendable` constraints on iterators since they ought to not be passed between `Task`s.

# Modification
Explicitly mark the `AsyncAdjacentPairsSequence` to be not `Sendable`.

# Result
Nobody can make this `Sendable`.