### PR TITLE
Remove `Sendable` constraint for `AsyncChain2Sequence`

### DIFF
--- a/Sources/AsyncAlgorithms/AsyncChain2Sequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncChain2Sequence.swift
@@ -80,4 +80,6 @@ extension AsyncChain2Sequence: AsyncSequence {
 }
 
 extension AsyncChain2Sequence: Sendable where Base1: Sendable, Base2: Sendable { }
-extension AsyncChain2Sequence.Iterator: Sendable where Base1.AsyncIterator: Sendable, Base2.AsyncIterator: Sendable { }
+
+@available(*, unavailable)
+extension AsyncChain2Sequence.Iterator: Sendable { }


### PR DESCRIPTION
# Motivation
We want to remove any `Sendable` constraints on iterators since they ought to not be passed between `Task`s.

# Modification
Explicitly mark the `AsyncChain2Sequence` to be not `Sendable`.

# Result
Nobody can make this `Sendable`.