### PR TITLE
[UnitTests] fix to harmonize debounce availability

### DIFF
--- a/Tests/AsyncAlgorithmsTests/Performance/TestThroughput.swift
+++ b/Tests/AsyncAlgorithmsTests/Performance/TestThroughput.swift
@@ -64,7 +64,7 @@ final class TestThroughput: XCTestCase {
       zip($0, $1, $2)
     }
   }
-  @available(macOS 13.0, *)
+  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
   func test_debounce() async {
       await measureSequenceThroughput(source: (1...).async) {
           $0.debounce(for: .zero, clock: ContinuousClock())


### PR DESCRIPTION
This PR applies the same `available` condition on TestThroughput/test_debounce() than the one on the `debounce` operator.

My environment is the following:

- macOS Monterey 12.6
- simulator iPhone 14 Pro iOS 16

The test target won't compile with the iOS simulator because of the current `available` statement.

Remark: the project does not compile since we removed the `Task.select` function (used by `combineLatest()`). I guess it is temporary waiting for the new implementation of `AsyncCombineLatestSequence`.