### PR TITLE
Ensure all imports of other modules are implementation only

### DIFF
--- a/Sources/AsyncAlgorithms/AsyncChannel.swift
+++ b/Sources/AsyncAlgorithms/AsyncChannel.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@preconcurrency import OrderedCollections
+@preconcurrency @_implementationOnly import OrderedCollections
 
 /// A channel for sending elements from one task to another with back pressure.
 ///

--- a/Sources/AsyncAlgorithms/AsyncThrowingChannel.swift
+++ b/Sources/AsyncAlgorithms/AsyncThrowingChannel.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@preconcurrency import OrderedCollections
+@preconcurrency @_implementationOnly import OrderedCollections
 
 /// An error-throwing channel for sending elements from on task to another with back pressure.
 ///

--- a/Sources/AsyncAlgorithms/CombineLatest/CombineLatestStateMachine.swift
+++ b/Sources/AsyncAlgorithms/CombineLatest/CombineLatestStateMachine.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import DequeModule
+@_implementationOnly import DequeModule
 
 /// State machine for combine latest
 struct CombineLatestStateMachine<

--- a/Sources/AsyncAlgorithms/Merge/AsyncMerge2Sequence.swift
+++ b/Sources/AsyncAlgorithms/Merge/AsyncMerge2Sequence.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import DequeModule
+@_implementationOnly import DequeModule
 
 /// Creates an asynchronous sequence of elements from two underlying asynchronous sequences
 public func merge<Base1: AsyncSequence, Base2: AsyncSequence>(_ base1: Base1, _ base2: Base2) -> AsyncMerge2Sequence<Base1, Base2>

--- a/Sources/AsyncAlgorithms/Merge/AsyncMerge3Sequence.swift
+++ b/Sources/AsyncAlgorithms/Merge/AsyncMerge3Sequence.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import DequeModule
+@_implementationOnly import DequeModule
 
 /// Creates an asynchronous sequence of elements from two underlying asynchronous sequences
 public func merge<

--- a/Sources/AsyncAlgorithms/Merge/MergeStateMachine.swift
+++ b/Sources/AsyncAlgorithms/Merge/MergeStateMachine.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import DequeModule
+@_implementationOnly import DequeModule
 
 /// The state machine for any of the `merge` operator.
 ///


### PR DESCRIPTION
This set of changes makes sure the imports for swift-collections are an implementation detail and don't leak out to exported scopes.