### PR TITLE
Relay algorithm

### DIFF
--- a/Evolution/NNNN-relay.md
+++ b/Evolution/NNNN-relay.md
@@ -1,0 +1,208 @@
+# Relay
+
+* Proposal: [SAA-NNNN](NNNN-relay.md)
+* Authors: [Tristan Celder](https://github.com/tcldr)
+* Review Manager: TBD
+* Status: **Implemented. Awaiting Feedback.**
+
+
+ * Implementation: [[Source](https://github.com/tcldr/swift-async-algorithms/blob/pr/relay/Sources/AsyncAlgorithms/AsyncRelay.swift) |
+ [Tests](https://github.com/tcldr/swift-async-algorithms/blob/pr/relay/Tests/AsyncAlgorithmsTests/TestRelay.swift)]
+
+## Introduction
+
+Swift's built in language features for asynchronous sequences provide a lightweight, ergonomic syntax for consuming elements from an asynchronous source, but creating those asynchronous sequences can sometimes feel a little more involved. `AsyncStream` works very well in its role of adapting traditional event sources into the world of structured concurrency, but there isn't an equivalent convenience for creating a natively asynchronous source.
+
+For example, if we wanted to output the Fibonacci seqeunce asynchronously as an `AsyncSequence`, we'd need to create a type similar to the following:
+
+```swift
+
+// This could of course be implemented as a non-async `Sequence`, but serves
+// well for illustrative purposes 
+struct AsyncFibonacciSequence: AsyncSequence: Sendable {
+  
+  typealias Element = Int
+  
+  struct Iterator: AsyncIteratorProtocol {
+    
+    var seed = (0, 1)
+    
+    mutating func next() async -> Element? {
+      if Task.isCancelled { return nil }
+      defer { seed = (seed.1, seed.0 + seed.1) }
+      return seed.0
+    }
+  }
+  
+  func makeAsyncIterator() -> Iterator {
+    Iterator()
+  }
+}
+
+let fibonacci = AsyncFibonacciSequence()
+
+```
+
+For simple routines, writing this amount of code creates unnecessary friction for programmers.
+
+In addition, it's difficult to share the sequence amongst tasks. While the sequence _does_ conform to `Sendable`, its iterator does not. This means that each time the sequence is iterated, it starts from the beginning. To circumvent this, a programmer may attempt to share an asynchronous sequence's iterator instead. But this would result in a compiler warning (and soon to be error) about attempting to send non-`Sendable` items across actor boundaries.
+
+## Proposed solution
+
+Asynchronous relays work in a similar way to what are sometimes called 'generators' in other languages. They expose a convenient shorthand that makes creating a producing asynchronous sequence, nearly as frictionless as consuming an asynchronous sequence.
+
+Here's how the Fibonacci asynchronous sequence above could be converted to an asynchronous relay with equivalent functionality:
+
+```swift  
+let fibonacci = AsyncRelaySequence { yield in
+  var seed = (0, 1)
+  while !Task.isCancelled {
+    await yield(seed.0)
+    seed = (seed.1, seed.0 + seed.1)
+  }
+}
+```
+
+But often, it's desirable to share a producing iterator across `Task`s. `AsyncRelay` faciliates this directly without a requirement to call `AsyncRelaySequence`s `makeAsyncIterator()` method:
+
+```swift
+
+// Now just `AsyncRelay` instead of `AsyncRelaySequence`
+let fibonacci = AsyncRelay { yield in 
+  var seed = (0, 1)
+  while !Task.isCancelled {
+    await yield(seed.0)
+    seed = (seed.1, seed.0 + seed.1)
+  }
+}
+
+Task {
+  let fib1 = await fibonacci.next()
+  ...
+}
+Task {
+  let fib2 = await fibonacci.next()
+  ...
+}
+Task {
+  let fib3 = await fibonacci.next()
+  ...
+}
+
+```
+
+`AsyncRelay` also has sibling throwing varieties, `AsyncThrowingRelay` and `AsyncThrowingRelaySequence`, which leverage Swift's built in control flow syntax to shutdown a relay when an `Error` is thrown. 
+
+```swift
+let imageRequest1 = ...
+let imageRequest2 = ...
+let imageRequest3 = ...
+let relay = AsyncThrowingRelay { yield in 
+  await yield(try await imageRequest1.fetch()) // Good.
+  await yield(try await imageRequest2.fetch()) // Throws! Relay will exit here and cancel.
+  await yield(try await imageRequest3.fetch()) // Doesn't get called.
+}
+
+// Somewhere else is the code... 
+
+do {
+  let image1 = try await relay.next() // Great.
+  let image2 = try await relay.next() // Uh-oh, Throws! 
+  let image3 = try await relay.next() // Doesn't get called.
+}
+...
+
+```
+
+## Detailed design
+
+```swift
+// An asynchronous sequence generated from a closure that limits its rate of
+// element production to the rate of element consumption
+//
+// ``AsyncRelaySequence`` conforms to ``AsyncSequence``, providing a convenient
+// way to create an asynchronous sequence without manually conforming a type
+// ``AsyncSequence``.
+//
+// You initialize an ``AsyncRelaySequence`` with a closure that receives an
+// ``AsyncRelay.Continuation``. Produce elements in this closure, then provide
+// them to the sequence by calling the suspending continuation. Execution will
+// resume as soon as the produced value is consumed. You call the continuation
+// instance directly because it defines a `callAsFunction()` method that Swift
+// calls when you call the instance. When there are no further elements to
+// produce, simply allow the function to exit. This causes the sequence
+// iterator to produce a nil, which terminates the sequence.
+//
+// Both ``AsyncRelaySequence`` and its iterator ``AsyncRelay`` conform to
+// ``Sendable``, which permits them being called from from concurrent contexts.
+public struct AsyncRelaySequence<Element: Sendable> : Sendable, AsyncSequence {
+  public typealias AsyncIterator = AsyncRelay<Element>
+  public init(_ producer: @escaping AsyncIterator.Producer)
+  public func makeAsyncIterator() -> AsyncRelay<Element>
+}
+
+// An asynchronous sequence iterator generated from a closure that limits its
+// rate of element production to the rate of element consumption
+//
+// For usage information see ``AsyncRelaySequence``.
+//
+// ``AsyncRelay`` conforms to ``Sendable``, which permits calling it from
+// concurrent contexts.
+public struct AsyncRelay<Element: Sendable> : Sendable, AsyncIteratorProtocol {
+  
+  public typealias Producer = @Sendable (Continuation) async -> Void
+  
+  public struct Continuation {    
+    public func callAsFunction(_ element: Element) async
+  }  
+  public func next() async -> Element?
+}
+
+// A throwing asynchronous sequence generated from a closure that limits its
+// rate of element production to the rate of element consumption
+//
+// ``AsyncThrowingRelaySequence`` conforms to ``AsyncSequence``, providing a
+// convenient way to create a throwing asynchronous sequence without manually
+// conforming a type ``AsyncSequence``.
+//
+// You initialize an ``AsyncThrowingRelaySequence`` with a closure that
+// receives an ``AsyncThrowingRelay.Continuation``. Produce elements in this
+// closure, then provide them to the sequence by calling the suspending
+// continuation. Execution will resume as soon as the value produced is
+// consumed. You call the continuation instance directly because it defines a
+// `callAsFunction()` method that Swift calls when you call the instance. When
+// there are no further elements to produce, simply allow the function to exit.
+// This causes the sequence to produce a nil, which terminates the sequence.
+// You may also choose to throw from within the closure which terminates the
+// sequence with an ``Error``.
+//
+// Both ``AsyncThrowingRelaySequence`` and its iterator ``AsyncThrowingRelay``
+// conform to ``Sendable``, which permits them being called from from
+// concurrent contexts.
+public struct AsyncThrowingRelaySequence<Element: Sendable> : Sendable, AsyncSequence {
+  
+  public typealias AsyncIterator = AsyncThrowingRelay<Element>  
+  public init(_ producer: @escaping AsyncIterator.Producer)  
+  public func makeAsyncIterator() -> AsyncThrowingRelay<Element>
+}
+
+// A throwing asynchronous sequence iterator generated from a closure that
+// limits its rate of element production to the rate of element consumption
+//
+// For usage information see ``AsyncThrowingRelaySequence``.
+//
+// ``AsyncThrowingRelay`` conforms to ``Sendable``, which permits calling it
+// from concurrent contexts.
+public struct AsyncThrowingRelay<Element: Sendable> : Sendable, AsyncIteratorProtocol {
+  public typealias Producer = @Sendable (Continuation) async throws -> Void
+  public struct Continuation {
+    public func callAsFunction(_ element: Element) async
+  }
+  public init(_ producer: @escaping Producer)
+  public func next() async throws -> Element?
+}
+```
+
+## Acknowledgmenets
+
+Asynchronous relays are heavily inspired by generators and sequence builders available in other languages.

--- a/Sources/AsyncAlgorithms/AsyncRelay.swift
+++ b/Sources/AsyncAlgorithms/AsyncRelay.swift
@@ -1,0 +1,411 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Async Algorithms open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import DequeModule
+
+// MARK: - AsyncRelay
+
+/// An asynchronous sequence generated from a closure that limits its rate of
+/// element production to the rate of element consumption
+///
+/// ``AsyncRelaySequence`` conforms to ``AsyncSequence``, providing a convenient
+/// way to create an asynchronous sequence without manually conforming a type
+/// ``AsyncSequence``.
+///
+/// You initialize an ``AsyncRelaySequence`` with a closure that receives an
+/// ``AsyncRelay.Continuation``. Produce elements in this closure, then provide
+/// them to the sequence by calling the suspending continuation. Execution will
+/// resume as soon as the value produced is consumed. You call the continuation
+/// instance directly because it defines a `callAsFunction()` method that Swift
+/// calls when you call the instance. When there are no further elements to
+/// produce, simply allow the function to exit. This causes the sequence
+/// iterator to produce a nil, which terminates the sequence.
+///
+/// Both ``AsyncRelaySequence`` and its iterator ``AsyncRelay`` conform to
+/// ``Sendable``, which permits them being called from from concurrent contexts.
+public struct AsyncRelaySequence<Element: Sendable> : Sendable, AsyncSequence {
+  
+  public typealias AsyncIterator = AsyncRelay<Element>
+  
+  private let producer: AsyncIterator.Producer
+  
+  public init(_ producer: @escaping AsyncIterator.Producer) {
+    self.producer = producer
+  }
+  
+  public func makeAsyncIterator() -> AsyncRelay<Element> {
+    .init(producer)
+  }
+}
+
+/// An asynchronous sequence iterator generated from a closure that limits its
+/// rate of element production to the rate of element consumption
+///
+/// For usage information see ``AsyncRelaySequence``.
+///
+/// ``AsyncRelay`` conforms to ``Sendable``, which permits calling it from
+/// concurrent contexts.
+public struct AsyncRelay<Element: Sendable> : Sendable, AsyncIteratorProtocol {
+  
+  public typealias Producer = @Sendable (Continuation) async -> Void
+  
+  public struct Continuation {
+    
+    private let context: RelayContext<Element>
+    
+    fileprivate init(_ context: RelayContext<Element>) {
+      self.context = context
+    }
+    
+    public func callAsFunction(_ element: Element) async {
+      await context.yield(element)
+    }
+  }
+  
+  private enum TaskState {
+    case pending
+    case running(Task<Void, Never>)
+    case terminal
+  }
+  
+  private let taskState = ManagedCriticalState<TaskState>(.pending)
+  private let context: RelayContext<Element>
+  private let producer: Producer
+  private let deallocToken: DeallocToken
+  
+  public init(_ producer: @escaping Producer) {
+    self.context = .init()
+    self.producer = producer
+    self.deallocToken = .init { [taskState, context] in
+      taskState.withCriticalRegion { taskState in
+        if case .running(let task) = taskState { task.cancel() }
+        taskState = .terminal
+      }
+      context.cancel()
+    }
+  }
+  
+  public func next() async -> Element? {
+    guard Task.isCancelled == false else { return nil }
+    taskState.withCriticalRegion { [producer, context] taskState in
+      guard case .pending = taskState else { return }
+      let task = Task {
+        await producer(Continuation(context))
+        context.cancel()
+      }
+      taskState = .running(task)
+    }
+    return await context.next()
+  }
+}
+
+// MARK: - AsyncThrowingRelay
+
+/// A throwing asynchronous sequence generated from a closure that limits its
+/// rate of element production to the rate of element consumption
+///
+/// ``AsyncThrowingRelaySequence`` conforms to ``AsyncSequence``, providing a
+/// convenient way to create a throwing asynchronous sequence without manually
+/// conforming a type ``AsyncSequence``.
+///
+/// You initialize an ``AsyncThrowingRelaySequence`` with a closure that
+/// receives an ``AsyncThrowingRelay.Continuation``. Produce elements in this
+/// closure, then provide them to the sequence by calling the suspending
+/// continuation. Execution will resume as soon as the value produced is
+/// consumed. You call the continuation instance directly because it defines a
+/// `callAsFunction()` method that Swift calls when you call the instance. When
+/// there are no further elements to produce, simply allow the function to exit.
+/// This causes the sequence to produce a nil, which terminates the sequence.
+/// You may also choose to throw from within the closure which terminates the
+/// sequence with an ``Error``.
+///
+/// Both ``AsyncThrowingRelaySequence`` and its iterator ``AsyncThrowingRelay``
+/// conform to ``Sendable``, which permits them being called from from
+/// concurrent contexts.
+public struct AsyncThrowingRelaySequence<Element: Sendable> : Sendable, AsyncSequence {
+  
+  public typealias AsyncIterator = AsyncThrowingRelay<Element>
+  
+  private let producer: AsyncIterator.Producer
+  
+  public init(_ producer: @escaping AsyncIterator.Producer) {
+    self.producer = producer
+  }
+  
+  public func makeAsyncIterator() -> AsyncThrowingRelay<Element> {
+    .init(producer)
+  }
+}
+
+/// A throwing asynchronous sequence iterator generated from a closure that
+/// limits its rate of element production to the rate of element consumption
+///
+/// For usage information see ``AsyncThrowingRelaySequence``.
+///
+/// ``AsyncThrowingRelay`` conforms to ``Sendable``, which permits calling it
+/// from concurrent contexts.
+public struct AsyncThrowingRelay<Element: Sendable> : Sendable, AsyncIteratorProtocol {
+  
+  public typealias Producer = @Sendable (Continuation) async throws -> Void
+  
+  public struct Continuation {
+    
+    private let context: RelayContext<Result<Element?, Error>>
+    
+    fileprivate init(_ context: RelayContext<Result<Element?, Error>>) {
+      self.context = context
+    }
+    
+    public func callAsFunction(_ element: Element) async {
+      await context.yield(.success(element))
+    }
+  }
+  
+  private enum TaskState {
+    case pending
+    case running(Task<Void, Never>)
+    case terminal
+  }
+  
+  private let taskState = ManagedCriticalState<TaskState>(.pending)
+  private let context: RelayContext<Result<Element?, Error>>
+  private let producer: Producer
+  private let deallocToken: DeallocToken
+  
+  public init(_ producer: @escaping Producer) {
+    self.context = .init()
+    self.producer = producer
+    self.deallocToken = .init  { [taskState, context] in
+      taskState.withCriticalRegion { taskState in
+        if case .running(let task) = taskState { task.cancel() }
+        taskState = .terminal
+      }
+      context.cancel()
+    }
+  }
+  
+  public func next() async throws -> Element? {
+    guard Task.isCancelled == false else { return nil }
+    taskState.withCriticalRegion { [producer, context] taskState in
+      guard case .pending = taskState else { return }
+      let task = Task {
+        do {
+          try await producer(Continuation(context))
+        }
+        catch {
+          await context.yield(.failure(error))
+        }
+        context.cancel()
+      }
+      taskState = .running(task)
+    }
+    let result = await context.next() ?? .success(nil)
+    return try result.get()
+  }
+}
+
+// MARK: - Relay Context
+
+fileprivate struct RelayContext<Element: Sendable> : Sendable {
+  
+  private typealias NextContinuation = @Sendable (Element?) -> Void
+  private typealias NextBox = SealableBox<NextContinuation>
+  
+  private struct State: Sendable {
+    
+    var active = true
+    var pendingNexts = Deque<NextBox>()
+    var pendingYield: UnsafeContinuation<Bool, Never>?
+    var pendingElement: Element?
+    
+    mutating func next(_ nextBox: NextBox) -> (() -> Void)? {
+      guard active else {
+        if let continuation = nextBox.remove(sealingForInsertions: true) {
+          return { continuation(nil) }
+        }
+        else {
+          return nil
+        }
+      }
+      // If there's already queued nexts, we should simply add to the back
+      // of the queue. It will be resumed in a later yield cycle.
+      guard pendingNexts.isEmpty else {
+        pendingNexts.append(nextBox)
+        return nil
+      }
+      return attemptNext(nextBox)
+    }
+    
+    private mutating func attemptNext(_ nextBox: NextBox) -> (() -> Void)? {
+      if let element = pendingElement {
+        guard let continuation = nextBox.remove(sealingForInsertions: true) else {
+          return nil
+        }
+        // We have an element already, so return it. No need to kick-off
+        // another cycle. The element was either produced as part of the first
+        // iteration, or from a previous next that was cancelled mid yield
+        // cycle
+        self.pendingElement = nil
+        return { continuation(element) }
+      }
+      else if let yield = pendingYield {
+        // there's no element, so we need to kick off a yield cycle to get one
+        pendingNexts.append(nextBox)
+        pendingYield = nil
+        return { yield.resume(returning: true) }
+      }
+      else {
+        // There's no element, OR pending yield. Probably arrived before the
+        // first iteration's `yield` call. Enqueue the pending `next`
+        // continuation and wait for `yield` to be called.
+        pendingNexts.append(nextBox)
+        return nil
+      }
+    }
+    
+    mutating func yield(
+      _ continuation: UnsafeContinuation<Bool, Never>, element: Element
+    ) -> (() -> Void)? {
+      precondition(pendingYield == nil, "attempt to await yield() on more then one task")
+      precondition(pendingElement == nil, "attempt to await yield() on more then one task")
+      // We're finishing a yield cycle so there should be a waiting next –
+      // assuming it wasn't cancelled
+      if let pendingNext = pendingNexts.first {
+        pendingNexts.removeFirst()
+        guard let nextContinuation = pendingNext.remove(sealingForInsertions: true) else {
+          // The waiting next was cancelled before being used. Try again. There
+          // may be another awaiting Task queued.
+          return yield(continuation, element: element)
+        }
+        if pendingNexts.isEmpty {
+          // There's no more tasks awaiting next after this one, hold on to the
+          // yield continuation until one arrives
+          self.pendingYield = continuation
+          return { nextContinuation(element) }
+        }
+        else {
+          // There's more tasks awaiting next after this one, so kick-off the
+          // next yield cycle straight away.
+          return {
+            nextContinuation(element)
+            continuation.resume(returning: true)
+          }
+        }
+      }
+      // There's no tasks awaiting next. Maybe they were cancelled. Or,
+      // perhaps this is the first iteration.
+      else {
+        self.pendingElement = element
+        self.pendingYield = continuation
+        return nil
+      }
+    }
+    
+    mutating func cancel() -> (() -> Void)? {
+      self.active = false
+      let pendingYield = self.pendingYield
+      let pendingNexts = self.pendingNexts.compactMap { box in
+        box.remove(sealingForInsertions: true)
+      }
+      self.pendingYield = nil
+      self.pendingElement = nil
+      self.pendingNexts.removeAll()
+      return {
+        for continuation in pendingNexts { continuation(nil) }
+        pendingYield?.resume(returning: false)
+      }
+    }
+  }
+  
+  private let state = ManagedCriticalState(State())
+  
+  func next() async -> Element? {
+    // triggers yield cycle, suspending until yield is called
+    let nextBox = NextBox()
+    return await withTaskCancellationHandler {
+      return await withUnsafeContinuation { continuation in
+        let contents = { @Sendable element in continuation.resume(returning: element) }
+        guard nextBox.insert(contents) else {
+          continuation.resume(returning: nil)
+          return
+        }
+        let resume = state.withCriticalRegion { state in state.next(nextBox) }
+        resume?()
+      }
+    } onCancel: {
+      guard let continuation = nextBox.remove(sealingForInsertions: true) else { return }
+      continuation(nil)
+    }
+  }
+  
+  @discardableResult
+  func yield(_ element: Element) async -> Bool {
+    // suspends yield cycle, suspending until next is called
+    await withUnsafeContinuation { continuation in
+      let resume = state.withCriticalRegion { state in
+        state.yield(continuation, element: element)
+      }
+      resume?()
+    }
+  }
+  
+  func cancel() {
+    let resume = state.withCriticalRegion { state in state.cancel() }
+    resume?()
+  }
+}
+
+// MARK: - Utilities
+
+fileprivate struct SealableBox<Element: Sendable>: Sendable {
+  
+  enum State {
+    case empty
+    case full(Element)
+    case sealed
+  }
+  
+  private let box = ManagedCriticalState(State.empty)
+  
+  func insert(_ element: Element) -> Bool {
+    box.withCriticalRegion { state in
+      guard case .empty = state else {
+        return false
+      }
+      state = .full(element)
+      return true
+    }
+  }
+  
+  func remove(sealingForInsertions sealed: Bool = false) -> Element? {
+    box.withCriticalRegion { state in
+      switch state {
+      case .empty:
+        state = sealed ? .sealed : .empty
+        return nil
+      case .full(let element):
+        state = sealed ? .sealed : .empty
+        return element
+      case .sealed:
+        return nil
+      }
+    }
+  }
+}
+
+/// A utility to perform deallocation tasks on value types
+fileprivate final class DeallocToken: Sendable {
+  let action: @Sendable () -> Void
+  init(_ dealloc: @escaping @Sendable () -> Void) {
+    self.action = dealloc
+  }
+  deinit { action() }
+}

--- a/Tests/AsyncAlgorithmsTests/TestRelay.swift
+++ b/Tests/AsyncAlgorithmsTests/TestRelay.swift
@@ -1,0 +1,357 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Async Algorithms open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+@preconcurrency import XCTest
+import AsyncAlgorithms
+
+final class TestRelay: XCTestCase {
+  
+  // MARK: - AsyncRelay
+  
+  func test_relay_basic() async {
+    let source = [0, 1, 2, 3, 4]
+    let expected = source
+    let relay = AsyncRelay { yield in
+      for item in source { await yield(item) }
+    }
+    var collected = [Int]()
+    while let item = await relay.next() {
+      collected.append(item)
+    }
+    XCTAssertEqual(expected, collected)
+  }
+  
+  func test_relay_returns_nil_past_end() async {
+    let source = [0, 1, 2, 3, 4]
+    let relay = AsyncRelay { yield in
+      for item in source { await yield(item) }
+    }
+    while let item = await relay.next() { XCTAssertNotNil(item) }
+    let pastEnd = await relay.next()
+    XCTAssertNil(pastEnd)
+  }
+  
+  func test_relay_consumer_cancellation() async {
+    let cancelled = expectation(description: "consumer cancelled")
+    let started = expectation(description: "relay started")
+    started.assertForOverFulfill = false
+    let relay = AsyncRelay<Int> { yield in
+      while !Task.isCancelled {
+        started.fulfill()
+      }
+    }
+    await withTaskGroup(of: Void.self) { group in
+      group.addTask {
+        let item = await relay.next()
+        XCTAssertNil(item)
+        cancelled.fulfill()
+      }
+      wait(for: [started], timeout: 1.0)
+      group.cancelAll()
+    }
+    wait(for: [cancelled], timeout: 1.0)
+  }
+  
+  func test_relay_inner_task_cancellation() async {
+    let started = expectation(description: "started indefinite task")
+    let finished = expectation(description: "finished indefinite task")
+    started.assertForOverFulfill = false
+    var relay: AsyncRelay<Int>! = AsyncRelay { yield in
+      while !Task.isCancelled {
+        started.fulfill()
+        await yield(0)
+      }
+      finished.fulfill()
+    }
+    let _ = await relay.next() // kicks off task
+    relay = nil
+    wait(for: [started, finished], timeout: 1.0)
+  }
+  
+  func test_relay_basic_parallelized() async {
+    let source = Array(0..<100)
+    let expected = source.reduce(0, +)
+    let relay = AsyncRelay { yield in
+      for item in source { await yield(item) }
+    }
+    let result = await withTaskGroup(of: [Int].self) { group in
+      for _ in 0..<16 {
+        group.addTask {
+          var collected = [Int]()
+          while let item = await relay.next() { collected.append(item) }
+          return collected
+        }
+      }
+      let results = await Array(group)
+      return results.flatMap { $0 }.reduce(0, +)
+    }
+    XCTAssertEqual(expected, result)
+  }
+  
+  func test_relay_consumer_cancellation_parallelized() async {
+    var tasks = [Task<Void, Never>]()
+    var iterated = [XCTestExpectation]()
+    var finished = [XCTestExpectation]()
+    let relay = AsyncRelay { yield in
+      while Task.isCancelled == false {
+        await yield(1)
+      }
+    }
+    for _ in 0..<64 {
+      let iterate = expectation(description: "task iterated")
+      iterate.assertForOverFulfill = false
+      let finish = expectation(description: "task finished")
+      iterated.append(iterate)
+      finished.append(finish)
+      let task = Task {
+        while let _ = await relay.next() {
+          iterate.fulfill()
+          await Task.yield()
+        }
+        finish.fulfill()
+      }
+      tasks.append(task)
+    }
+    wait(for: iterated, timeout: 1.0)
+    for task in tasks { task.cancel() }
+    wait(for: finished, timeout: 1.0)
+  }
+  
+  // MARK: - AsyncThrowingRelay
+  
+  func test_throwing_relay_basic() async throws {
+    let source = [0, 1, 2, 3, 4]
+    let expected = source
+    let relay = AsyncThrowingRelay { yield in
+      for item in source { await yield(item) }
+    }
+    var collected = [Int]()
+    while let item = try await relay.next() {
+      collected.append(item)
+    }
+    XCTAssertEqual(expected, collected)
+  }
+  
+  func test_throwing_relay_returns_nil_past_end() async throws {
+    let source = [0, 1, 2, 3, 4]
+    let relay = AsyncThrowingRelay { yield in
+      for item in source { await yield(item) }
+    }
+    while let item = try await relay.next() { XCTAssertNotNil(item) }
+    let pastEnd = try await relay.next()
+    XCTAssertNil(pastEnd)
+  }
+  
+  func test_throwing_relay_throws() async {
+    let source = [0, 1, 2, 3, 4]
+    let expected = [0, 1, 2]
+    let relay = AsyncThrowingRelay { yield in
+      for item in source { await yield(try throwOn(3, item)) }
+    }
+    var collected = [Int]()
+    var failure: Error?
+    do {
+      while let item = try await relay.next() {
+        collected.append(item)
+      }
+    }
+    catch {
+      failure = error
+    }
+    XCTAssertEqual(expected, collected)
+    XCTAssertEqual(Failure(), failure as? Failure)
+  }
+  
+  func test_throwing_relay_returns_nil_past_end_after_throw() async throws {
+    let source = [0, 1, 2, 3, 4]
+    let relay = AsyncThrowingRelay { yield in
+      for item in source { await yield(try throwOn(3, item)) }
+    }
+    var failure: Error?
+    do {
+      while let item = try await relay.next() { XCTAssertNotNil(item) }
+    }
+    catch {
+      failure = error
+    }
+    let pastEnd = try await relay.next()
+    XCTAssertNil(pastEnd)
+    XCTAssertEqual(Failure(), failure as? Failure)
+  }
+  
+  func test_throwing_relay_consumer_cancellation() async {
+    let cancelled = expectation(description: "consumer cancelled")
+    let started = expectation(description: "relay started")
+    started.assertForOverFulfill = false
+    let relay = AsyncThrowingRelay<Int> { yield in
+      while true {
+        started.fulfill()
+        if Task.isCancelled { break }
+      }
+    }
+    await withThrowingTaskGroup(of: Void.self) { group in
+      group.addTask {
+        do {
+          let item = try await relay.next()
+          XCTAssertNil(item)
+          cancelled.fulfill()
+        }
+        catch { XCTFail("threw unexpectedly") }
+      }
+      wait(for: [started], timeout: 1.0)
+      group.cancelAll()
+    }
+    wait(for: [cancelled], timeout: 1.0)
+  }
+  
+  func test_throwing_relay_inner_task_cancellation() async {
+    let started = expectation(description: "started indefinite task")
+    let finished = expectation(description: "finished indefinite task")
+    started.assertForOverFulfill = false
+    var relay: AsyncThrowingRelay<Int>! = AsyncThrowingRelay { yield in
+      await yield(0)
+      while true {
+        started.fulfill()
+        if Task.isCancelled { break }
+      }
+      finished.fulfill()
+    }
+    let _ = try? await relay.next() // kicks off task
+    relay = nil
+    wait(for: [started, finished], timeout: 1.0)
+  }
+  
+  func test_throwing_relay_basic_parallelized() async throws {
+    let source = Array(0..<100)
+    let expected = source.reduce(0, +)
+    let relay = AsyncThrowingRelay { yield in
+      for item in source { await yield(item) }
+    }
+    let result = try await withThrowingTaskGroup(of: [Int].self) { group in
+      for _ in 0..<16 {
+        group.addTask {
+          var collected = [Int]()
+          while let item = try await relay.next() {
+            collected.append(item)
+            await Task.yield()
+          }
+          return collected
+        }
+      }
+      let results = try await Array(group)
+      return results.flatMap { $0 }.reduce(0, +)
+    }
+    XCTAssertEqual(expected, result)
+  }
+  
+  func test_throwing_relay_parallelized_throws() async {
+    let source = Array(0..<100)
+    let expected = 50
+    let threw = expectation(description: "throws")
+    let relay = AsyncThrowingRelay { yield in
+      for item in source {
+        let _ = try throwOn(50, item)
+        await yield(1)
+      }
+    }
+    let result = await withTaskGroup(of: [Int].self) { group in
+      for _ in 0..<16 {
+        group.addTask {
+          var collected = [Int]()
+          do {
+            while let item = try await relay.next() {
+              collected.append(item)
+              await Task.yield()
+            }
+          }
+          catch {
+            threw.fulfill()
+          }
+          return collected
+        }
+      }
+      let results = await Array(group)
+      return results.flatMap { $0 }.reduce(0, +)
+    }
+    wait(for: [threw], timeout: 1.0)
+    XCTAssertEqual(expected, result)
+  }
+  
+  func test_throwing_relay_consumer_cancellation_parallelized() async {
+    var tasks = [Task<Void, Never>]()
+    var iterated = [XCTestExpectation]()
+    var finished = [XCTestExpectation]()
+    let relay = AsyncThrowingRelay { yield in
+      while Task.isCancelled == false {
+        await yield(1)
+      }
+    }
+    for _ in 0..<64 {
+      let iterate = expectation(description: "task iterated")
+      iterate.assertForOverFulfill = false
+      let finish = expectation(description: "task finished")
+      iterated.append(iterate)
+      finished.append(finish)
+      let task = Task {
+        do {
+          while let _ = try await relay.next() {
+            iterate.fulfill()
+            await Task.yield()
+          }
+        }
+        catch { XCTFail("threw unexpectedly") }
+        finish.fulfill()
+      }
+      tasks.append(task)
+    }
+    wait(for: iterated, timeout: 1.0)
+    for task in tasks { task.cancel() }
+    wait(for: finished, timeout: 1.0)
+  }
+  
+  // MARK: - AsyncRelaySequence
+  
+  func test_relay_sequence_basic() async {
+    let source = [0, 1, 2, 3, 4]
+    let expected = source
+    let sequence = AsyncRelaySequence { yield in
+      for item in source { await yield(item) }
+    }
+    var collected0 = [Int]()
+    var collected1 = [Int]()
+    var collected2 = [Int]()
+    for await item in sequence { collected0.append(item) }
+    for await item in sequence { collected1.append(item) }
+    for await item in sequence { collected2.append(item) }
+    XCTAssertEqual(expected, collected0)
+    XCTAssertEqual(expected, collected1)
+    XCTAssertEqual(expected, collected2)
+  }
+  
+  // MARK: - AsyncRelayThrowingSequence
+  
+  func test_relay_throwing_sequence_basic() async throws {
+    let source = [0, 1, 2, 3, 4]
+    let expected = source
+    let sequence = AsyncThrowingRelaySequence { yield in
+      for item in source { await yield(item) }
+    }
+    var collected0 = [Int]()
+    var collected1 = [Int]()
+    var collected2 = [Int]()
+    for try await item in sequence { collected0.append(item) }
+    for try await item in sequence { collected1.append(item) }
+    for try await item in sequence { collected2.append(item) }
+    XCTAssertEqual(expected, collected0)
+    XCTAssertEqual(expected, collected1)
+    XCTAssertEqual(expected, collected2)
+  }
+}


### PR DESCRIPTION
# Relay

* Proposal: [SAA-NNNN](NNNN-relay.md)
* Authors: [Tristan Celder](https://github.com/tcldr)
* Review Manager: TBD
* Status: **Implemented. Awaiting Feedback.**


 * Implementation: [[Source](https://github.com/tcldr/swift-async-algorithms/blob/pr/relay/Sources/AsyncAlgorithms/AsyncRelay.swift) |
 [Tests](https://github.com/tcldr/swift-async-algorithms/blob/pr/relay/Tests/AsyncAlgorithmsTests/TestRelay.swift)]

## Introduction

Swift's built in language features for asynchronous sequences provide a lightweight, ergonomic syntax for consuming elements from an asynchronous source, but creating those asynchronous sequences can sometimes feel a little more involved. `AsyncStream` works very well in its role of adapting traditional event sources into the world of structured concurrency, but there isn't an equivalent convenience for creating a natively asynchronous source.

For example, if we wanted to output the Fibonacci seqeunce asynchronously as an `AsyncSequence`, we'd need to create a type similar to the following:

```swift

// This could of course be implemented as a non-async `Sequence`, but serves
// well for illustrative purposes 
struct AsyncFibonacciSequence: AsyncSequence: Sendable {
  
  typealias Element = Int
  
  struct Iterator: AsyncIteratorProtocol {
    
    var seed = (0, 1)
    
    mutating func next() async -> Element? {
      if Task.isCancelled { return nil }
      defer { seed = (seed.1, seed.0 + seed.1) }
      return seed.0
    }
  }
  
  func makeAsyncIterator() -> Iterator {
    Iterator()
  }
}

let fibonacci = AsyncFibonacciSequence()

```

For simple routines, writing this amount of code creates unnecessary friction for programmers.

In addition, it's difficult to share the sequence amongst tasks. While the sequence _does_ conform to `Sendable`, its iterator does not. This means that each time the sequence is iterated, it starts from the beginning. To circumvent this, a programmer may attempt to share an asynchronous sequence's iterator instead. But this would result in a compiler warning (and soon to be error) about attempting to send non-`Sendable` items across actor boundaries.

## Proposed solution

Asynchronous relays work in a similar way to what are sometimes called 'generators' in other languages. They expose a convenient shorthand that makes creating a producing asynchronous sequence, nearly as frictionless as consuming an asynchronous sequence.

Here's how the Fibonacci asynchronous sequence above could be converted to an asynchronous relay with equivalent functionality:

```swift  
let fibonacci = AsyncRelaySequence { yield in
  var seed = (0, 1)
  while !Task.isCancelled {
    await yield(seed.0)
    seed = (seed.1, seed.0 + seed.1)
  }
}
```

But often, it's desirable to share a producing iterator across `Task`s. `AsyncRelay` faciliates this directly without a requirement to call `AsyncRelaySequence`s `makeAsyncIterator()` method:

```swift

// Now just `AsyncRelay` instead of `AsyncRelaySequence`
let fibonacci = AsyncRelay { yield in 
  var seed = (0, 1)
  while !Task.isCancelled {
    await yield(seed.0)
    seed = (seed.1, seed.0 + seed.1)
  }
}

Task {
  let fib1 = await fibonacci.next()
  ...
}
Task {
  let fib2 = await fibonacci.next()
  ...
}
Task {
  let fib3 = await fibonacci.next()
  ...
}

```

`AsyncRelay` also has sibling throwing varieties, `AsyncThrowingRelay` and `AsyncThrowingRelaySequence`, which leverage Swift's built in control flow syntax to shutdown a relay when an `Error` is thrown. 

```swift
let imageRequest1 = ...
let imageRequest2 = ...
let imageRequest3 = ...
let relay = AsyncThrowingRelay { yield in 
  await yield(try await imageRequest1.fetch()) // Good.
  await yield(try await imageRequest2.fetch()) // Throws! Relay will exit here and cancel.
  await yield(try await imageRequest3.fetch()) // Doesn't get called.
}

// Somewhere else is the code... 

do {
  let image1 = try await relay.next() // Great.
  let image2 = try await relay.next() // Uh-oh, Throws! 
  let image3 = try await relay.next() // Doesn't get called.
}
...

```

## Detailed design

```swift
// An asynchronous sequence generated from a closure that limits its rate of
// element production to the rate of element consumption
//
// ``AsyncRelaySequence`` conforms to ``AsyncSequence``, providing a convenient
// way to create an asynchronous sequence without manually conforming a type
// ``AsyncSequence``.
//
// You initialize an ``AsyncRelaySequence`` with a closure that receives an
// ``AsyncRelay.Continuation``. Produce elements in this closure, then provide
// them to the sequence by calling the suspending continuation. Execution will
// resume as soon as the produced value is consumed. You call the continuation
// instance directly because it defines a `callAsFunction()` method that Swift
// calls when you call the instance. When there are no further elements to
// produce, simply allow the function to exit. This causes the sequence
// iterator to produce a nil, which terminates the sequence.
//
// Both ``AsyncRelaySequence`` and its iterator ``AsyncRelay`` conform to
// ``Sendable``, which permits them being called from from concurrent contexts.
public struct AsyncRelaySequence<Element: Sendable> : Sendable, AsyncSequence {
  public typealias AsyncIterator = AsyncRelay<Element>
  public init(_ producer: @escaping AsyncIterator.Producer)
  public func makeAsyncIterator() -> AsyncRelay<Element>
}

// An asynchronous sequence iterator generated from a closure that limits its
// rate of element production to the rate of element consumption
//
// For usage information see ``AsyncRelaySequence``.
//
// ``AsyncRelay`` conforms to ``Sendable``, which permits calling it from
// concurrent contexts.
public struct AsyncRelay<Element: Sendable> : Sendable, AsyncIteratorProtocol {
  
  public typealias Producer = @Sendable (Continuation) async -> Void
  
  public struct Continuation {    
    public func callAsFunction(_ element: Element) async
  }  
  public func next() async -> Element?
}

// A throwing asynchronous sequence generated from a closure that limits its
// rate of element production to the rate of element consumption
//
// ``AsyncThrowingRelaySequence`` conforms to ``AsyncSequence``, providing a
// convenient way to create a throwing asynchronous sequence without manually
// conforming a type ``AsyncSequence``.
//
// You initialize an ``AsyncThrowingRelaySequence`` with a closure that
// receives an ``AsyncThrowingRelay.Continuation``. Produce elements in this
// closure, then provide them to the sequence by calling the suspending
// continuation. Execution will resume as soon as the value produced is
// consumed. You call the continuation instance directly because it defines a
// `callAsFunction()` method that Swift calls when you call the instance. When
// there are no further elements to produce, simply allow the function to exit.
// This causes the sequence to produce a nil, which terminates the sequence.
// You may also choose to throw from within the closure which terminates the
// sequence with an ``Error``.
//
// Both ``AsyncThrowingRelaySequence`` and its iterator ``AsyncThrowingRelay``
// conform to ``Sendable``, which permits them being called from from
// concurrent contexts.
public struct AsyncThrowingRelaySequence<Element: Sendable> : Sendable, AsyncSequence {
  
  public typealias AsyncIterator = AsyncThrowingRelay<Element>  
  public init(_ producer: @escaping AsyncIterator.Producer)  
  public func makeAsyncIterator() -> AsyncThrowingRelay<Element>
}

// A throwing asynchronous sequence iterator generated from a closure that
// limits its rate of element production to the rate of element consumption
//
// For usage information see ``AsyncThrowingRelaySequence``.
//
// ``AsyncThrowingRelay`` conforms to ``Sendable``, which permits calling it
// from concurrent contexts.
public struct AsyncThrowingRelay<Element: Sendable> : Sendable, AsyncIteratorProtocol {
  public typealias Producer = @Sendable (Continuation) async throws -> Void
  public struct Continuation {
    public func callAsFunction(_ element: Element) async
  }
  public init(_ producer: @escaping Producer)
  public func next() async throws -> Element?
}
```

## Acknowledgmenets

Asynchronous relays are heavily inspired by generators and sequence builders available in other languages.
