### PR TITLE
Add precondition guards to pthread_mutex calls

### DIFF
--- a/Sources/AsyncAlgorithms/Locking.swift
+++ b/Sources/AsyncAlgorithms/Locking.swift
@@ -37,7 +37,7 @@ internal struct Lock {
 #if canImport(Darwin)
     platformLock.initialize(to: os_unfair_lock())
 #elseif canImport(Glibc)
-    pthread_mutex_init(platformLock, nil)
+    precondition(pthread_mutex_init(platformLock, nil) == 0, "pthread_mutex_init failed")
 #elseif canImport(WinSDK)
     InitializeSRWLock(platformLock)
 #endif
@@ -45,7 +45,7 @@ internal struct Lock {
   
   fileprivate static func deinitialize(_ platformLock: PlatformLock) {
 #if canImport(Glibc)
-    pthread_mutex_destroy(platformLock)
+    precondition(pthread_mutex_destroy(platformLock) == 0, "pthread_mutex_destroy failed")
 #endif
     platformLock.deinitialize(count: 1)
   }
@@ -64,7 +64,7 @@ internal struct Lock {
 #if canImport(Darwin)
     os_unfair_lock_unlock(platformLock)
 #elseif canImport(Glibc)
-    pthread_mutex_unlock(platformLock)
+    precondition(pthread_mutex_unlock(platformLock) == 0, "pthread_mutex_unlock failed")
 #elseif canImport(WinSDK)
     ReleaseSRWLockExclusive(platformLock)
 #endif


### PR DESCRIPTION
While in the current configuration lock/unlock shouldn't ever fail, it seems polite to guard against basic misuse in debug builds.