### PR TITLE
Switch from `group.waitForAll()` to `group.next()`

### DIFF
--- a/Sources/AsyncAlgorithms/CombineLatest/CombineLatestStateMachine.swift
+++ b/Sources/AsyncAlgorithms/CombineLatest/CombineLatestStateMachine.swift
@@ -530,7 +530,8 @@ struct CombineLatestStateMachine<
       preconditionFailure("Internal inconsistency current state \(self.state) and received upstreamThrew()")
 
     case .upstreamsFinished:
-      preconditionFailure("Internal inconsistency current state \(self.state) and received upstreamThrew()")
+      // We need to tolerate multiple upstreams failing
+      return .none
 
     case .waitingForDemand(let task, let upstreams, _):
       // An upstream threw. We can cancel everything now and transition to finished.

--- a/Sources/AsyncAlgorithms/Debounce/DebounceStateMachine.swift
+++ b/Sources/AsyncAlgorithms/Debounce/DebounceStateMachine.swift
@@ -390,8 +390,8 @@ struct DebounceStateMachine<Base: AsyncSequence, C: Clock> {
             preconditionFailure("Internal inconsistency current state \(self.state) and received upstreamFinished()")
 
         case .upstreamFailure:
-            // The upstream already failed so it should never have throw again.
-            preconditionFailure("Internal inconsistency current state \(self.state) and received childTaskSuspended()")
+            // We need to tolerate multiple upstreams failing
+            return .none
 
         case .waitingForDemand(let task, .none, let clockContinuation, .none):
             // We don't have any buffered element so we can just go ahead


### PR DESCRIPTION
# Motivation
Swift 5.8 is including a change to how `group.waitForAll()` is working. It now properly waits for all tasks to finish even if one of the tasks throws. We have used `group.waitForAll()` in multiple places and need to change this code accordingly.

# Modification
Switch code from `group.waitForAll()` to `group.next()`.

# Result
This fixes a few stuck tests that we have seen when running against development snapshots.