### PR TITLE
Package.swift: make package name consistent with repo name

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 import PackageDescription
 
 let package = Package(
-  name: "AsyncAlgorithms",
+  name: "swift-async-algorithms",
   platforms: [
     .macOS("10.15"),
     .iOS("13.0"),


### PR DESCRIPTION
Rest of SwiftPM packages provided by Apple follow a dash-case naming scheme consistent with repository name, usually 
with `swift-` prefix. See attached screenshot:

<img width="303" alt="Screenshot 2023-02-28 at 12 57 06" src="https://user-images.githubusercontent.com/112310/221860367-bac5c564-ef45-4696-92bc-811efa2ce914.png">
