### PR TITLE
Audit pass on inline and initialization

### DIFF
--- a/Sources/AsyncAlgorithms/AsyncInclusiveReductionsSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncInclusiveReductionsSequence.swift
@@ -58,7 +58,7 @@ extension AsyncInclusiveReductionsSequence: AsyncSequence {
     internal let transform: @Sendable (Base.Element, Base.Element) async -> Base.Element
 
     @inlinable
-    internal init(
+    init(
       _ iterator: Base.AsyncIterator,
       transform: @Sendable @escaping (Base.Element, Base.Element) async -> Base.Element
     ) {

--- a/Sources/AsyncAlgorithms/AsyncThrowingInclusiveReductionsSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncThrowingInclusiveReductionsSequence.swift
@@ -57,7 +57,7 @@ extension AsyncThrowingInclusiveReductionsSequence: AsyncSequence {
     internal let transform: @Sendable (Base.Element, Base.Element) async throws -> Base.Element
 
     @inlinable
-    internal init(
+    init(
       _ iterator: Base.AsyncIterator,
       transform: @Sendable @escaping (Base.Element, Base.Element) async throws -> Base.Element
     ) {

--- a/Sources/AsyncAlgorithms/Buffer/AsyncBufferSequence.swift
+++ b/Sources/AsyncAlgorithms/Buffer/AsyncBufferSequence.swift
@@ -70,7 +70,7 @@ public struct AsyncBufferSequencePolicy: Sendable {
 
 /// An `AsyncSequence` that buffers elements in regard to a policy.
 public struct AsyncBufferSequence<Base: AsyncSequence & Sendable>: AsyncSequence {
-  enum StorageType<Base: AsyncSequence> {
+  enum StorageType {
     case transparent(Base.AsyncIterator)
     case bounded(storage: BoundedBufferStorage<Base>)
     case unbounded(storage: UnboundedBufferStorage<Base>)
@@ -82,7 +82,7 @@ public struct AsyncBufferSequence<Base: AsyncSequence & Sendable>: AsyncSequence
   let base: Base
   let policy: AsyncBufferSequencePolicy
 
-  public init(
+  init(
     base: Base,
     policy: AsyncBufferSequencePolicy
   ) {
@@ -91,7 +91,7 @@ public struct AsyncBufferSequence<Base: AsyncSequence & Sendable>: AsyncSequence
   }
 
   public func makeAsyncIterator() -> Iterator {
-    let storageType: StorageType<Base>
+    let storageType: StorageType
     switch self.policy.policy {
       case .bounded(...0), .bufferingNewest(...0), .bufferingOldest(...0):
         storageType = .transparent(self.base.makeAsyncIterator())
@@ -108,7 +108,7 @@ public struct AsyncBufferSequence<Base: AsyncSequence & Sendable>: AsyncSequence
   }
 
   public struct Iterator: AsyncIteratorProtocol {
-    var storageType: StorageType<Base>
+    var storageType: StorageType
 
     public mutating func next() async rethrows -> Element? {
       switch self.storageType {

--- a/Sources/AsyncAlgorithms/CombineLatest/AsyncCombineLatest2Sequence.swift
+++ b/Sources/AsyncAlgorithms/CombineLatest/AsyncCombineLatest2Sequence.swift
@@ -46,7 +46,7 @@ public struct AsyncCombineLatest2Sequence<
   let base1: Base1
   let base2: Base2
 
-  public init(_ base1: Base1, _ base2: Base2) {
+  init(_ base1: Base1, _ base2: Base2) {
     self.base1 = base1
     self.base2 = base2
   }

--- a/Sources/AsyncAlgorithms/Debounce/AsyncDebounceSequence.swift
+++ b/Sources/AsyncAlgorithms/Debounce/AsyncDebounceSequence.swift
@@ -41,7 +41,7 @@ public struct AsyncDebounceSequence<Base: AsyncSequence, C: Clock>: Sendable whe
     ///   - interval: The interval to debounce.
     ///   - tolerance: The tolerance of the clock.
     ///   - clock: The clock.
-    public init(_ base: Base, interval: C.Instant.Duration, tolerance: C.Instant.Duration?, clock: C) {
+    init(_ base: Base, interval: C.Instant.Duration, tolerance: C.Instant.Duration?, clock: C) {
         self.base = base
         self.interval = interval
         self.tolerance = tolerance

--- a/Sources/AsyncAlgorithms/Interspersed/AsyncInterspersedSequence.swift
+++ b/Sources/AsyncAlgorithms/Interspersed/AsyncInterspersedSequence.swift
@@ -45,7 +45,7 @@ public struct AsyncInterspersedSequence<Base: AsyncSequence> {
   internal let separator: Base.Element
 
   @usableFromInline
-  internal init(_ base: Base, separator: Base.Element) {
+  init(_ base: Base, separator: Base.Element) {
     self.base = base
     self.separator = separator
   }
@@ -73,7 +73,7 @@ extension AsyncInterspersedSequence: AsyncSequence {
     internal var state = State.start
 
     @usableFromInline
-    internal init(_ iterator: Base.AsyncIterator, separator: Base.Element) {
+    init(_ iterator: Base.AsyncIterator, separator: Base.Element) {
       self.iterator = iterator
       self.separator = separator
     }

--- a/Sources/AsyncAlgorithms/Merge/AsyncMerge2Sequence.swift
+++ b/Sources/AsyncAlgorithms/Merge/AsyncMerge2Sequence.swift
@@ -40,7 +40,7 @@ public struct AsyncMerge2Sequence<
     /// - Parameters:
     ///     - base1: The first upstream ``Swift/AsyncSequence``.
     ///     - base2: The second upstream ``Swift/AsyncSequence``.
-    public init(
+    init(
         _ base1: Base1,
         _ base2: Base2
     ) {

--- a/Sources/AsyncAlgorithms/Merge/AsyncMerge3Sequence.swift
+++ b/Sources/AsyncAlgorithms/Merge/AsyncMerge3Sequence.swift
@@ -49,7 +49,7 @@ public struct AsyncMerge3Sequence<
     ///     - base1: The first upstream ``Swift/AsyncSequence``.
     ///     - base2: The second upstream ``Swift/AsyncSequence``.
     ///     - base3: The third upstream ``Swift/AsyncSequence``.
-    public init(
+    init(
         _ base1: Base1,
         _ base2: Base2,
         _ base3: Base3


### PR DESCRIPTION
This is a comprehensive audit of the initializers and inline ABI boundaries of all API types. 

The primary entry point for all transformations is the extension to AsyncSequence unless the type is a public interface as an AsyncIteratorProtocol.