### PR TITLE
Audit pass on Sendable conformances and requirements

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,12 +20,7 @@ let package = Package(
   targets: [
     .target(
       name: "AsyncAlgorithms",
-      dependencies: [.product(name: "Collections", package: "swift-collections"),],
-      swiftSettings: [
-        .unsafeFlags([
-          "-strict-concurrency=complete"
-        ], .when(configuration: .debug))
-      ]
+      dependencies: [.product(name: "Collections", package: "swift-collections")]
     ),
     .target(
       name: "AsyncSequenceValidation",

--- a/Package.swift
+++ b/Package.swift
@@ -16,11 +16,16 @@ let package = Package(
     .library(name: "_CAsyncSequenceValidationSupport", type: .static, targets: ["AsyncSequenceValidation"]),
     .library(name: "AsyncAlgorithms_XCTest", targets: ["AsyncAlgorithms_XCTest"]),
   ],
-  dependencies: [.package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.0.3"))],
+  dependencies: [.package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.0.4"))],
   targets: [
     .target(
       name: "AsyncAlgorithms",
-      dependencies: [.product(name: "Collections", package: "swift-collections")]
+      dependencies: [.product(name: "Collections", package: "swift-collections"),],
+      swiftSettings: [
+        .unsafeFlags([
+          "-strict-concurrency=complete"
+        ], .when(configuration: .debug))
+      ]
     ),
     .target(
       name: "AsyncSequenceValidation",

--- a/Sources/AsyncAlgorithms/Buffer/BoundedBufferStateMachine.swift
+++ b/Sources/AsyncAlgorithms/Buffer/BoundedBufferStateMachine.swift
@@ -16,7 +16,7 @@ struct BoundedBufferStateMachine<Base: AsyncSequence> {
   typealias SuspendedProducer = UnsafeContinuation<Void, Never>
   typealias SuspendedConsumer = UnsafeContinuation<Result<Base.Element, Error>?, Never>
 
-  private enum State {
+  fileprivate enum State {
     case initial(base: Base)
     case buffering(
       task: Task<Void, Never>,
@@ -308,3 +308,6 @@ struct BoundedBufferStateMachine<Base: AsyncSequence> {
     }
   }
 }
+
+extension BoundedBufferStateMachine: Sendable where Base: Sendable { }
+extension BoundedBufferStateMachine.State: Sendable where Base: Sendable { }

--- a/Sources/AsyncAlgorithms/Buffer/UnboundedBufferStateMachine.swift
+++ b/Sources/AsyncAlgorithms/Buffer/UnboundedBufferStateMachine.swift
@@ -21,7 +21,7 @@ struct UnboundedBufferStateMachine<Base: AsyncSequence> {
     case bufferingOldest(Int)
   }
 
-  private enum State {
+  fileprivate enum State {
     case initial(base: Base)
     case buffering(
       task: Task<Void, Never>,
@@ -248,3 +248,6 @@ struct UnboundedBufferStateMachine<Base: AsyncSequence> {
     }
   }
 }
+
+extension UnboundedBufferStateMachine: Sendable where Base: Sendable { }
+extension UnboundedBufferStateMachine.State: Sendable where Base: Sendable { }

--- a/Sources/AsyncAlgorithms/Channels/AsyncChannel.swift
+++ b/Sources/AsyncAlgorithms/Channels/AsyncChannel.swift
@@ -19,7 +19,7 @@
 /// on the `Iterator` is made, or when `finish()` is called from another Task.
 /// As `finish()` induces a terminal state, there is no more need for a back pressure management.
 /// This function does not suspend and will finish all the pending iterations.
-public final class AsyncChannel<Element>: AsyncSequence, @unchecked Sendable {
+public final class AsyncChannel<Element: Sendable>: AsyncSequence, @unchecked Sendable {
   public typealias Element = Element
   public typealias AsyncIterator = Iterator
 

--- a/Sources/AsyncAlgorithms/Channels/AsyncThrowingChannel.swift
+++ b/Sources/AsyncAlgorithms/Channels/AsyncThrowingChannel.swift
@@ -18,7 +18,7 @@
 /// and is resumed when the next call to `next()` on the `Iterator` is made, or when `finish()`/`fail(_:)` is called
 /// from another Task. As `finish()` and `fail(_:)` induce a terminal state, there is no more need for a back pressure management.
 /// Those functions do not suspend and will finish all the pending iterations.
-public final class AsyncThrowingChannel<Element, Failure: Error>: AsyncSequence, @unchecked Sendable {
+public final class AsyncThrowingChannel<Element: Sendable, Failure: Error>: AsyncSequence, @unchecked Sendable {
   public typealias Element = Element
   public typealias AsyncIterator = Iterator
 

--- a/Sources/AsyncAlgorithms/Channels/ChannelStateMachine.swift
+++ b/Sources/AsyncAlgorithms/Channels/ChannelStateMachine.swift
@@ -10,39 +10,8 @@
 //===----------------------------------------------------------------------===//
 @_implementationOnly import OrderedCollections
 
-struct OrderedSetContainer<Element: Hashable> {
-  var contents: OrderedSet<Element>
-  
-  var isEmpty: Bool { contents.isEmpty }
-  
-  mutating func removeFirst() -> Element  {
-    contents.removeFirst()
-  }
-  
-  mutating func remove(_ element: Element) -> Element? {
-    contents.remove(element)
-  }
-  
-  @discardableResult
-  mutating func append(_ element: Element) -> (inserted: Bool, index: Int) {
-    contents.append(element)
-  }
-  
-  func map<T>(_ apply: (Element) throws -> T) rethrows -> [T] {
-    try contents.map(apply)
-  }
-}
-
-extension OrderedSetContainer: ExpressibleByArrayLiteral {
-  typealias ArrayLiteralElement = OrderedSet<Element>.ArrayLiteralElement
-  
-  init(arrayLiteral elements: ArrayLiteralElement...) {
-    contents = OrderedSet(elements)
-  }
-}
-
-extension OrderedSetContainer: @unchecked Sendable where Element: Sendable { }
-
+// NOTE: this is only marked as unchecked since the swift-collections tag is before auditing for Sendable
+extension OrderedSet: @unchecked Sendable where Element: Sendable { }
 
 struct ChannelStateMachine<Element: Sendable, Failure: Error>: Sendable {
   private struct SuspendedProducer: Hashable, Sendable {
@@ -87,9 +56,9 @@ struct ChannelStateMachine<Element: Sendable, Failure: Error>: Sendable {
 
   private enum State: Sendable {
     case channeling(
-      suspendedProducers: OrderedSetContainer<SuspendedProducer>,
+      suspendedProducers: OrderedSet<SuspendedProducer>,
       cancelledProducers: Set<SuspendedProducer>,
-      suspendedConsumers: OrderedSetContainer<SuspendedConsumer>,
+      suspendedConsumers: OrderedSet<SuspendedConsumer>,
       cancelledConsumers: Set<SuspendedConsumer>
     )
     case terminated(Termination)

--- a/Sources/AsyncAlgorithms/Channels/ChannelStorage.swift
+++ b/Sources/AsyncAlgorithms/Channels/ChannelStorage.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/LICENSE.txt for license information
 //
 //===----------------------------------------------------------------------===//
-struct ChannelStorage<Element, Failure: Error>: Sendable {
+struct ChannelStorage<Element: Sendable, Failure: Error>: Sendable {
   private let stateMachine: ManagedCriticalState<ChannelStateMachine<Element, Failure>>
   private let ids = ManagedCriticalState<UInt64>(0)
 


### PR DESCRIPTION
This brings the main API surface up to Sendable clean in complete mode. 

The primary point of change is Async(Throwing)Channel. Which previously permitted a potential Sendability soundness hole. It now requires that AsyncChannel's Element type MUST be Sendable. The reasoning is that this type's primary use case is to send elements from one isolation to another. This means that the element must be Sendable to achieve this.