### PR TITLE
Add WebAssembly support

### DIFF
--- a/Sources/AsyncAlgorithms/Locking.swift
+++ b/Sources/AsyncAlgorithms/Locking.swift
@@ -24,6 +24,8 @@ internal struct Lock {
   typealias Primitive = pthread_mutex_t
 #elseif canImport(WinSDK)
   typealias Primitive = SRWLOCK
+#else
+  typealias Primitive = Int
 #endif
   
   typealias PlatformLock = UnsafeMutablePointer<Primitive>

--- a/Sources/AsyncSequenceValidation/TaskDriver.swift
+++ b/Sources/AsyncSequenceValidation/TaskDriver.swift
@@ -50,8 +50,12 @@ final class TaskDriver {
   }
   
   func start() {
+#if canImport(Darwin) || canImport(Glibc)
     pthread_create(&thread, nil, start_thread,
       Unmanaged.passRetained(self).toOpaque())
+#elseif canImport(WinSDK)
+#error("TODO: Port TaskDriver threading to windows")
+#endif
   }
   
   func run() {


### PR DESCRIPTION
Hi everyone,

This PR adds support for WebAssembly (and possibly other single threaded environments).
I made the primitive an Int instead of a Void to avoid the `UnsafeMutablePointer<Void> has been replaced by UnsafeMutableRawPointer` warning.

<details>
  <summary>Build and tests running on SwiftWasm on Linux</summary>

```
root@684f97f7b63f:/# swift --version
SwiftWasm Swift version 5.8 (swiftlang-5.8.0)
Target: x86_64-unknown-linux-gnu
root@684f97f7b63f:/# cd saa/
root@684f97f7b63f:/saa# swift build
Building for debugging...
[145/145] Merging module AsyncAlgorithms_XCTest
Build complete! (58.26s)
root@684f97f7b63f:/saa# swift test 
Building for debugging...
[50/50] Linking swift-async-algorithmsPackageTests.xctest
Build complete! (32.33s)
Test Suite 'All tests' started at 2023-06-23 16:47:58.676
Test Suite 'debug.xctest' started at 2023-06-23 16:47:58.759
Test Suite 'TestAdjacentPairs' started at 2023-06-23 16:47:58.771
Test Case 'TestAdjacentPairs.test_adjacentPairs_finishes_when_iteration_task_is_cancelled' started at 2023-06-23 16:47:58.776
Test Case 'TestAdjacentPairs.test_adjacentPairs_finishes_when_iteration_task_is_cancelled' passed (0.048 seconds)
Test Case 'TestAdjacentPairs.test_adjacentPairs_forwards_termination_from_source_when_iteration_is_finished' started at 2023-06-23 16:47:58.825
Test Case 'TestAdjacentPairs.test_adjacentPairs_forwards_termination_from_source_when_iteration_is_finished' passed (0.004 seconds)
Test Case 'TestAdjacentPairs.test_adjacentPairs_produces_empty_sequence_when_source_sequence_is_empty' started at 2023-06-23 16:47:58.829
Test Case 'TestAdjacentPairs.test_adjacentPairs_produces_empty_sequence_when_source_sequence_is_empty' passed (0.005 seconds)
Test Case 'TestAdjacentPairs.test_adjacentPairs_produces_tuples_of_adjacent_values_of_original_element' started at 2023-06-23 16:47:58.834
Test Case 'TestAdjacentPairs.test_adjacentPairs_produces_tuples_of_adjacent_values_of_original_element' passed (0.005 seconds)
Test Case 'TestAdjacentPairs.test_adjacentPairs_throws_when_source_sequence_throws' started at 2023-06-23 16:47:58.839
Test Case 'TestAdjacentPairs.test_adjacentPairs_throws_when_source_sequence_throws' passed (0.003 seconds)
Test Suite 'TestAdjacentPairs' passed at 2023-06-23 16:47:58.843
Executed 5 tests, with 0 failures (0 unexpected) in 0.066 (0.066) seconds
Test Suite 'TestBuffer' started at 2023-06-23 16:47:58.844
Test Case 'TestBuffer.test_given_a_base_sequence_when_bounded_with_limit_0_then_the_policy_is_transparent' started at 2023-06-23 16:47:58.844
Test Case 'TestBuffer.test_given_a_base_sequence_when_bounded_with_limit_0_then_the_policy_is_transparent' passed (0.042 seconds)
Test Case 'TestBuffer.test_given_a_base_sequence_when_bufferingNewest_at_slow_pace_then_no_element_is_dropped' started at 2023-06-23 16:47:58.886
Test Case 'TestBuffer.test_given_a_base_sequence_when_bufferingNewest_at_slow_pace_then_no_element_is_dropped' passed (0.027 seconds)
Test Case 'TestBuffer.test_given_a_base_sequence_when_bufferingNewest_then_the_policy_is_applied' started at 2023-06-23 16:47:58.913
Test Case 'TestBuffer.test_given_a_base_sequence_when_bufferingNewest_then_the_policy_is_applied' passed (0.015 seconds)
Test Case 'TestBuffer.test_given_a_base_sequence_when_bufferingNewest_with_limit_0_then_the_policy_is_transparent' started at 2023-06-23 16:47:58.929
Test Case 'TestBuffer.test_given_a_base_sequence_when_bufferingNewest_with_limit_0_then_the_policy_is_transparent' passed (0.01 seconds)
Test Case 'TestBuffer.test_given_a_base_sequence_when_bufferingOldest_at_slow_pace_then_no_element_is_dropped' started at 2023-06-23 16:47:58.939
Test Case 'TestBuffer.test_given_a_base_sequence_when_bufferingOldest_at_slow_pace_then_no_element_is_dropped' passed (0.013 seconds)
Test Case 'TestBuffer.test_given_a_base_sequence_when_bufferingOldest_then_the_policy_is_applied' started at 2023-06-23 16:47:58.951
Test Case 'TestBuffer.test_given_a_base_sequence_when_bufferingOldest_then_the_policy_is_applied' passed (0.017 seconds)
Test Case 'TestBuffer.test_given_a_base_sequence_when_bufferingOldest_with_0_limit_then_the_policy_is_transparent' started at 2023-06-23 16:47:58.969
Test Case 'TestBuffer.test_given_a_base_sequence_when_bufferingOldest_with_0_limit_then_the_policy_is_transparent' passed (0.01 seconds)
Test Case 'TestBuffer.test_given_a_base_sequence_when_buffering_with_bounded_then_the_buffer_is_filled_in_and_suspends' started at 2023-06-23 16:47:58.979
Test Case 'TestBuffer.test_given_a_base_sequence_when_buffering_with_bounded_then_the_buffer_is_filled_in_and_suspends' passed (0.012 seconds)
Test Case 'TestBuffer.test_given_a_base_sequence_when_buffering_with_unbounded_then_the_buffer_is_filled_in' started at 2023-06-23 16:47:58.992
Test Case 'TestBuffer.test_given_a_base_sequence_when_buffering_with_unbounded_then_the_buffer_is_filled_in' passed (0.004 seconds)
Test Case 'TestBuffer.test_given_a_buffered_bounded_sequence_when_cancelling_consumer_then_the_iteration_finishes_and_the_base_is_cancelled' started at 2023-06-23 16:47:58.996
Test Case 'TestBuffer.test_given_a_buffered_bounded_sequence_when_cancelling_consumer_then_the_iteration_finishes_and_the_base_is_cancelled' passed (0.004 seconds)
Test Case 'TestBuffer.test_given_a_buffered_with_unbounded_sequence_when_cancelling_consumer_then_the_iteration_finishes_and_the_base_is_cancelled' started at 2023-06-23 16:47:58.999
Test Case 'TestBuffer.test_given_a_buffered_with_unbounded_sequence_when_cancelling_consumer_then_the_iteration_finishes_and_the_base_is_cancelled' passed (0.004 seconds)
Test Case 'TestBuffer.test_given_a_failable_base_sequence_when_bufferingNewest_then_the_failure_is_forwarded' started at 2023-06-23 16:47:59.004
Test Case 'TestBuffer.test_given_a_failable_base_sequence_when_bufferingNewest_then_the_failure_is_forwarded' passed (0.016 seconds)
Test Case 'TestBuffer.test_given_a_failable_base_sequence_when_bufferingOldest_then_the_failure_is_forwarded' started at 2023-06-23 16:47:59.020
Test Case 'TestBuffer.test_given_a_failable_base_sequence_when_bufferingOldest_then_the_failure_is_forwarded' passed (0.012 seconds)
Test Case 'TestBuffer.test_given_a_failable_base_sequence_when_buffering_with_bounded_then_the_failure_is_forwarded' started at 2023-06-23 16:47:59.032
Test Case 'TestBuffer.test_given_a_failable_base_sequence_when_buffering_with_bounded_then_the_failure_is_forwarded' passed (0.004 seconds)
Test Case 'TestBuffer.test_given_a_failable_base_sequence_when_buffering_with_unbounded_then_the_failure_is_forwarded' started at 2023-06-23 16:47:59.036
Test Case 'TestBuffer.test_given_a_failable_base_sequence_when_buffering_with_unbounded_then_the_failure_is_forwarded' passed (0.004 seconds)
Test Suite 'TestBuffer' passed at 2023-06-23 16:47:59.041
Executed 15 tests, with 0 failures (0 unexpected) in 0.194 (0.194) seconds
Test Suite 'TestBufferedByteIterator' started at 2023-06-23 16:47:59.041
Test Case 'TestBufferedByteIterator.test_cancellation' started at 2023-06-23 16:47:59.041
Test Case 'TestBufferedByteIterator.test_cancellation' passed (0.005 seconds)
Test Case 'TestBufferedByteIterator.test_immediately_empty' started at 2023-06-23 16:47:59.046
Test Case 'TestBufferedByteIterator.test_immediately_empty' passed (0.002 seconds)
Test Case 'TestBufferedByteIterator.test_one_pass' started at 2023-06-23 16:47:59.048
Test Case 'TestBufferedByteIterator.test_one_pass' passed (0.003 seconds)
Test Case 'TestBufferedByteIterator.test_three_pass' started at 2023-06-23 16:47:59.051
Test Case 'TestBufferedByteIterator.test_three_pass' passed (0.002 seconds)
Test Case 'TestBufferedByteIterator.test_three_pass_throwing' started at 2023-06-23 16:47:59.054
Test Case 'TestBufferedByteIterator.test_three_pass_throwing' passed (0.002 seconds)
Test Suite 'TestBufferedByteIterator' passed at 2023-06-23 16:47:59.056
Executed 5 tests, with 0 failures (0 unexpected) in 0.015 (0.015) seconds
Test Suite 'TestChain2' started at 2023-06-23 16:47:59.056
Test Case 'TestChain2.test_chain2_concatenates_elements_from_sequences_and_returns_nil_when_source_is_pastEnd' started at 2023-06-23 16:47:59.057
Test Case 'TestChain2.test_chain2_concatenates_elements_from_sequences_and_returns_nil_when_source_is_pastEnd' passed (0.004 seconds)
Test Case 'TestChain2.test_chain2_finishes_when_task_is_cancelled' started at 2023-06-23 16:47:59.060
Test Case 'TestChain2.test_chain2_finishes_when_task_is_cancelled' passed (0.004 seconds)
Test Case 'TestChain2.test_chain2_outputs_elements_from_first_sequence_and_throws_when_first_throws' started at 2023-06-23 16:47:59.064
Test Case 'TestChain2.test_chain2_outputs_elements_from_first_sequence_and_throws_when_first_throws' passed (0.002 seconds)
Test Case 'TestChain2.test_chain2_outputs_elements_from_sequences_and_throws_when_second_throws' started at 2023-06-23 16:47:59.066
Test Case 'TestChain2.test_chain2_outputs_elements_from_sequences_and_throws_when_second_throws' passed (0.002 seconds)
Test Suite 'TestChain2' passed at 2023-06-23 16:47:59.069
Executed 4 tests, with 0 failures (0 unexpected) in 0.012 (0.012) seconds
Test Suite 'TestChain3' started at 2023-06-23 16:47:59.069
Test Case 'TestChain3.test_chain3_concatenates_elements_from_sequences_and_returns_nil_when_source_is_pastEnd' started at 2023-06-23 16:47:59.069
Test Case 'TestChain3.test_chain3_concatenates_elements_from_sequences_and_returns_nil_when_source_is_pastEnd' passed (0.006 seconds)
Test Case 'TestChain3.test_chain3_finishes_when_task_is_cancelled' started at 2023-06-23 16:47:59.075
Test Case 'TestChain3.test_chain3_finishes_when_task_is_cancelled' passed (0.003 seconds)
Test Case 'TestChain3.test_chain3_outputs_elements_from_first_sequence_and_throws_when_first_throws' started at 2023-06-23 16:47:59.078
Test Case 'TestChain3.test_chain3_outputs_elements_from_first_sequence_and_throws_when_first_throws' passed (0.002 seconds)
Test Case 'TestChain3.test_chain3_outputs_elements_from_sequences_and_throws_when_second_throws' started at 2023-06-23 16:47:59.081
Test Case 'TestChain3.test_chain3_outputs_elements_from_sequences_and_throws_when_second_throws' passed (0.003 seconds)
Test Case 'TestChain3.test_chain3_outputs_elements_from_sequences_and_throws_when_third_throws' started at 2023-06-23 16:47:59.084
Test Case 'TestChain3.test_chain3_outputs_elements_from_sequences_and_throws_when_third_throws' passed (0.002 seconds)
Test Suite 'TestChain3' passed at 2023-06-23 16:47:59.086
Executed 5 tests, with 0 failures (0 unexpected) in 0.016 (0.016) seconds
Test Suite 'TestChannel' started at 2023-06-23 16:47:59.086
Test Case 'TestChannel.test_asyncChannel_delivers_elements_when_several_producers_and_several_consumers' started at 2023-06-23 16:47:59.086
Test Case 'TestChannel.test_asyncChannel_delivers_elements_when_several_producers_and_several_consumers' passed (0.023 seconds)
Test Case 'TestChannel.test_asyncChannel_resumes_consumer_when_task_is_cancelled' started at 2023-06-23 16:47:59.110
Test Case 'TestChannel.test_asyncChannel_resumes_consumer_when_task_is_cancelled' passed (0.004 seconds)
Test Case 'TestChannel.test_asyncChannel_resumes_consumers_when_finish_is_called' started at 2023-06-23 16:47:59.114
Test Case 'TestChannel.test_asyncChannel_resumes_consumers_when_finish_is_called' passed (0.004 seconds)
Test Case 'TestChannel.test_asyncChannel_resumes_producer_when_task_is_cancelled' started at 2023-06-23 16:47:59.118
Test Case 'TestChannel.test_asyncChannel_resumes_producer_when_task_is_cancelled' passed (0.003 seconds)
Test Case 'TestChannel.test_asyncChannel_resumes_producers_and_discards_additional_elements_when_finish_is_called' started at 2023-06-23 16:47:59.122
Test Case 'TestChannel.test_asyncChannel_resumes_producers_and_discards_additional_elements_when_finish_is_called' passed (0.002 seconds)
Test Suite 'TestChannel' passed at 2023-06-23 16:47:59.123
Executed 5 tests, with 0 failures (0 unexpected) in 0.037 (0.037) seconds
Test Suite 'TestChunk' started at 2023-06-23 16:47:59.124
Test Case 'TestChunk.test_count' started at 2023-06-23 16:47:59.124
Test Case 'TestChunk.test_count' passed (0.013 seconds)
Test Case 'TestChunk.test_count_error' started at 2023-06-23 16:47:59.137
Test Case 'TestChunk.test_count_error' passed (0.005 seconds)
Test Case 'TestChunk.test_count_nonuniformTiming' started at 2023-06-23 16:47:59.142
Test Case 'TestChunk.test_count_nonuniformTiming' passed (0.009 seconds)
Test Case 'TestChunk.test_count_trailingChunk' started at 2023-06-23 16:47:59.151
Test Case 'TestChunk.test_count_trailingChunk' passed (0.009 seconds)
Test Case 'TestChunk.test_group' started at 2023-06-23 16:47:59.161
Test Case 'TestChunk.test_group' passed (0.018 seconds)
Test Case 'TestChunk.test_group_error' started at 2023-06-23 16:47:59.179
Test Case 'TestChunk.test_group_error' passed (0.008 seconds)
Test Case 'TestChunk.test_group_singleGroup' started at 2023-06-23 16:47:59.186
Test Case 'TestChunk.test_group_singleGroup' passed (0.008 seconds)
Test Case 'TestChunk.test_group_singleValue' started at 2023-06-23 16:47:59.194
Test Case 'TestChunk.test_group_singleValue' passed (0.005 seconds)
Test Case 'TestChunk.test_projection' started at 2023-06-23 16:47:59.200
Test Case 'TestChunk.test_projection' passed (0.015 seconds)
Test Case 'TestChunk.test_projection_error' started at 2023-06-23 16:47:59.214
Test Case 'TestChunk.test_projection_error' passed (0.005 seconds)
Test Case 'TestChunk.test_projection_singleGroup' started at 2023-06-23 16:47:59.219
Test Case 'TestChunk.test_projection_singleGroup' passed (0.009 seconds)
Test Case 'TestChunk.test_projection_singleValue' started at 2023-06-23 16:47:59.228
Test Case 'TestChunk.test_projection_singleValue' passed (0.007 seconds)
Test Case 'TestChunk.test_signalAndCount_countAlwaysPrevails' started at 2023-06-23 16:47:59.236
Test Case 'TestChunk.test_signalAndCount_countAlwaysPrevails' passed (0.04 seconds)
Test Case 'TestChunk.test_signalAndCount_countResetsAfterCount' started at 2023-06-23 16:47:59.276
Test Case 'TestChunk.test_signalAndCount_countResetsAfterCount' passed (0.037 seconds)
Test Case 'TestChunk.test_signalAndCount_countResetsAfterSignal' started at 2023-06-23 16:47:59.313
Test Case 'TestChunk.test_signalAndCount_countResetsAfterSignal' passed (0.029 seconds)
Test Case 'TestChunk.test_signalAndCount_error' started at 2023-06-23 16:47:59.342
Test Case 'TestChunk.test_signalAndCount_error' passed (0.015 seconds)
Test Case 'TestChunk.test_signalAndCount_signalAlwaysPrevails' started at 2023-06-23 16:47:59.358
Test Case 'TestChunk.test_signalAndCount_signalAlwaysPrevails' passed (0.05 seconds)
Test Case 'TestChunk.test_signal_emptyChunks' started at 2023-06-23 16:47:59.407
Test Case 'TestChunk.test_signal_emptyChunks' passed (0.021 seconds)
Test Case 'TestChunk.test_signal_equalChunks' started at 2023-06-23 16:47:59.429
Test Case 'TestChunk.test_signal_equalChunks' passed (0.042 seconds)
Test Case 'TestChunk.test_signal_error' started at 2023-06-23 16:47:59.471
Test Case 'TestChunk.test_signal_error' passed (0.014 seconds)
Test Case 'TestChunk.test_signal_unequalChunks' started at 2023-06-23 16:47:59.485
Test Case 'TestChunk.test_signal_unequalChunks' passed (0.05 seconds)
Test Case 'TestChunk.test_signal_unsignaledTrailingChunk' started at 2023-06-23 16:47:59.535
Test Case 'TestChunk.test_signal_unsignaledTrailingChunk' passed (0.027 seconds)
Test Case 'TestChunk.test_timeAndCount_countAlwaysPrevails' started at 2023-06-23 16:47:59.562
Test Case 'TestChunk.test_timeAndCount_countAlwaysPrevails' passed (0.027 seconds)
Test Case 'TestChunk.test_timeAndCount_countResetsAfterCount' started at 2023-06-23 16:47:59.589
Test Case 'TestChunk.test_timeAndCount_countResetsAfterCount' passed (0.039 seconds)
Test Case 'TestChunk.test_timeAndCount_countResetsAfterSignal' started at 2023-06-23 16:47:59.628
Test Case 'TestChunk.test_timeAndCount_countResetsAfterSignal' passed (0.032 seconds)
Test Case 'TestChunk.test_timeAndCount_error' started at 2023-06-23 16:47:59.660
Test Case 'TestChunk.test_timeAndCount_error' passed (0.016 seconds)
Test Case 'TestChunk.test_timeAndCount_timeAlwaysPrevails' started at 2023-06-23 16:47:59.676
Test Case 'TestChunk.test_timeAndCount_timeAlwaysPrevails' passed (0.046 seconds)
Test Case 'TestChunk.test_time_emptyChunks' started at 2023-06-23 16:47:59.723
Test Case 'TestChunk.test_time_emptyChunks' passed (0.019 seconds)
Test Case 'TestChunk.test_time_equalChunks' started at 2023-06-23 16:47:59.742
Test Case 'TestChunk.test_time_equalChunks' passed (0.042 seconds)
Test Case 'TestChunk.test_time_error' started at 2023-06-23 16:47:59.784
Test Case 'TestChunk.test_time_error' passed (0.012 seconds)
Test Case 'TestChunk.test_time_unequalChunks' started at 2023-06-23 16:47:59.797
Test Case 'TestChunk.test_time_unequalChunks' passed (0.047 seconds)
Test Case 'TestChunk.test_time_unsignaledTrailingChunk' started at 2023-06-23 16:47:59.844
Test Case 'TestChunk.test_time_unsignaledTrailingChunk' passed (0.03 seconds)
Test Suite 'TestChunk' passed at 2023-06-23 16:47:59.874
Executed 32 tests, with 0 failures (0 unexpected) in 0.745 (0.745) seconds
Test Suite 'TestCombineLatest2' started at 2023-06-23 16:47:59.874
Test Case 'TestCombineLatest2.test_cancellation' started at 2023-06-23 16:47:59.874
Test Case 'TestCombineLatest2.test_cancellation' passed (0.023 seconds)
Test Case 'TestCombineLatest2.test_combineLatest' started at 2023-06-23 16:47:59.898
Test Case 'TestCombineLatest2.test_combineLatest' passed (0.006 seconds)
Test Case 'TestCombineLatest2.test_combineLatest_when_cancelled' started at 2023-06-23 16:47:59.903
Test Case 'TestCombineLatest2.test_combineLatest_when_cancelled' passed (0.001 seconds)
Test Case 'TestCombineLatest2.test_ordering1' started at 2023-06-23 16:47:59.905
Test Case 'TestCombineLatest2.test_ordering1' passed (0.009 seconds)
Test Case 'TestCombineLatest2.test_ordering2' started at 2023-06-23 16:47:59.914
Test Case 'TestCombineLatest2.test_ordering2' passed (0.006 seconds)
Test Case 'TestCombineLatest2.test_ordering3' started at 2023-06-23 16:47:59.920
Test Case 'TestCombineLatest2.test_ordering3' passed (0.005 seconds)
Test Case 'TestCombineLatest2.test_ordering4' started at 2023-06-23 16:47:59.925
Test Case 'TestCombineLatest2.test_ordering4' passed (0.007 seconds)
Test Case 'TestCombineLatest2.test_throwing_combineLatest1' started at 2023-06-23 16:47:59.932
Test Case 'TestCombineLatest2.test_throwing_combineLatest1' passed (0.004 seconds)
Test Case 'TestCombineLatest2.test_throwing_combineLatest2' started at 2023-06-23 16:47:59.935
Test Case 'TestCombineLatest2.test_throwing_combineLatest2' passed (0.005 seconds)
Test Case 'TestCombineLatest2.test_throwing_ordering1' started at 2023-06-23 16:47:59.940
Test Case 'TestCombineLatest2.test_throwing_ordering1' passed (0.006 seconds)
Test Case 'TestCombineLatest2.test_throwing_ordering2' started at 2023-06-23 16:47:59.947
Test Case 'TestCombineLatest2.test_throwing_ordering2' passed (0.005 seconds)
Test Suite 'TestCombineLatest2' passed at 2023-06-23 16:47:59.952
Executed 11 tests, with 0 failures (0 unexpected) in 0.076 (0.076) seconds
Test Suite 'TestCombineLatest3' started at 2023-06-23 16:47:59.952
Test Case 'TestCombineLatest3.test_combineLatest' started at 2023-06-23 16:47:59.952
Test Case 'TestCombineLatest3.test_combineLatest' passed (0.008 seconds)
Test Case 'TestCombineLatest3.test_ordering1' started at 2023-06-23 16:47:59.960
Test Case 'TestCombineLatest3.test_ordering1' passed (0.008 seconds)
Test Suite 'TestCombineLatest3' passed at 2023-06-23 16:47:59.969
Executed 2 tests, with 0 failures (0 unexpected) in 0.016 (0.016) seconds
Test Suite 'TestCompacted' started at 2023-06-23 16:47:59.969
Test Case 'TestCompacted.test_compacted_finishes_when_iteration_task_is_cancelled' started at 2023-06-23 16:47:59.969
Test Case 'TestCompacted.test_compacted_finishes_when_iteration_task_is_cancelled' passed (0.004 seconds)
Test Case 'TestCompacted.test_compacted_is_equivalent_to_compactMap_when_input_as_nil_elements' started at 2023-06-23 16:47:59.973
Test Case 'TestCompacted.test_compacted_is_equivalent_to_compactMap_when_input_as_nil_elements' passed (0.003 seconds)
Test Case 'TestCompacted.test_compacted_is_equivalent_to_compactMap_when_input_as_no_nil_elements' started at 2023-06-23 16:47:59.976
Test Case 'TestCompacted.test_compacted_is_equivalent_to_compactMap_when_input_as_no_nil_elements' passed (0.001 seconds)
Test Case 'TestCompacted.test_compacted_produces_nil_next_element_when_iteration_is_finished' started at 2023-06-23 16:47:59.978
Test Case 'TestCompacted.test_compacted_produces_nil_next_element_when_iteration_is_finished' passed (0.001 seconds)
Test Case 'TestCompacted.test_compacted_throws_when_root_sequence_throws' started at 2023-06-23 16:47:59.979
Test Case 'TestCompacted.test_compacted_throws_when_root_sequence_throws' passed (0.002 seconds)
Test Suite 'TestCompacted' passed at 2023-06-23 16:47:59.981
Executed 5 tests, with 0 failures (0 unexpected) in 0.012 (0.012) seconds
Test Suite 'TestDebounce' started at 2023-06-23 16:47:59.982
Test Case 'TestDebounce.test_Rethrows' started at 2023-06-23 16:47:59.982
Test Case 'TestDebounce.test_Rethrows' passed (0.019 seconds)
Test Case 'TestDebounce.test_debounce_when_cancelled' started at 2023-06-23 16:48:00.001
Test Case 'TestDebounce.test_debounce_when_cancelled' passed (0.001 seconds)
Test Case 'TestDebounce.test_delayingValues' started at 2023-06-23 16:48:00.002
Test Case 'TestDebounce.test_delayingValues' passed (0.026 seconds)
Test Case 'TestDebounce.test_delayingValues_dangling_last' started at 2023-06-23 16:48:00.029
Test Case 'TestDebounce.test_delayingValues_dangling_last' passed (0.023 seconds)
Test Case 'TestDebounce.test_finishDoesntDebounce' started at 2023-06-23 16:48:00.052
Test Case 'TestDebounce.test_finishDoesntDebounce' passed (0.008 seconds)
Test Case 'TestDebounce.test_noValues' started at 2023-06-23 16:48:00.060
Test Case 'TestDebounce.test_noValues' passed (0.007 seconds)
Test Case 'TestDebounce.test_throwDoesntDebounce' started at 2023-06-23 16:48:00.068
Test Case 'TestDebounce.test_throwDoesntDebounce' passed (0.012 seconds)
Test Suite 'TestDebounce' passed at 2023-06-23 16:48:00.080
	 Executed 7 tests, with 0 failures (0 unexpected) in 0.097 (0.097) seconds
Test Suite 'TestDictionary' started at 2023-06-23 16:48:00.080
Test Case 'TestDictionary.test_grouping' started at 2023-06-23 16:48:00.080
Test Case 'TestDictionary.test_grouping' passed (0.004 seconds)
Test Case 'TestDictionary.test_throwing_grouping' started at 2023-06-23 16:48:00.084
Test Case 'TestDictionary.test_throwing_grouping' passed (0.002 seconds)
Test Case 'TestDictionary.test_throwing_uniqueKeysAndValues' started at 2023-06-23 16:48:00.086
Test Case 'TestDictionary.test_throwing_uniqueKeysAndValues' passed (0.002 seconds)
Test Case 'TestDictionary.test_throwing_uniquingWith' started at 2023-06-23 16:48:00.089
Test Case 'TestDictionary.test_throwing_uniquingWith' passed (0.002 seconds)
Test Case 'TestDictionary.test_uniqueKeysAndValues' started at 2023-06-23 16:48:00.091
Test Case 'TestDictionary.test_uniqueKeysAndValues' passed (0.002 seconds)
Test Case 'TestDictionary.test_uniquingWith' started at 2023-06-23 16:48:00.093
Test Case 'TestDictionary.test_uniquingWith' passed (0.003 seconds)
Test Suite 'TestDictionary' passed at 2023-06-23 16:48:00.096
Executed 6 tests, with 0 failures (0 unexpected) in 0.015 (0.015) seconds
Test Suite 'TestInterspersed' started at 2023-06-23 16:48:00.096
Test Case 'TestInterspersed.test_cancellation' started at 2023-06-23 16:48:00.096
Test Case 'TestInterspersed.test_cancellation' passed (0.006 seconds)
Test Case 'TestInterspersed.test_interspersed' started at 2023-06-23 16:48:00.102
Test Case 'TestInterspersed.test_interspersed' passed (0.002 seconds)
Test Case 'TestInterspersed.test_interspersed_empty' started at 2023-06-23 16:48:00.103
Test Case 'TestInterspersed.test_interspersed_empty' passed (0.002 seconds)
Test Case 'TestInterspersed.test_interspersed_with_throwing_upstream' started at 2023-06-23 16:48:00.105
Test Case 'TestInterspersed.test_interspersed_with_throwing_upstream' passed (0.002 seconds)
Test Suite 'TestInterspersed' passed at 2023-06-23 16:48:00.108
Executed 4 tests, with 0 failures (0 unexpected) in 0.011 (0.011) seconds
Test Suite 'TestJoined' started at 2023-06-23 16:48:00.108
Test Case 'TestJoined.test_cancellation' started at 2023-06-23 16:48:00.108
Test Case 'TestJoined.test_cancellation' passed (0.005 seconds)
Test Case 'TestJoined.test_join' started at 2023-06-23 16:48:00.113
Test Case 'TestJoined.test_join' passed (0.003 seconds)
Test Case 'TestJoined.test_join_empty' started at 2023-06-23 16:48:00.117
Test Case 'TestJoined.test_join_empty' passed (0.001 seconds)
Test Case 'TestJoined.test_join_single_sequence' started at 2023-06-23 16:48:00.118
Test Case 'TestJoined.test_join_single_sequence' passed (0.002 seconds)
Test Case 'TestJoined.test_throwing' started at 2023-06-23 16:48:00.120
Test Case 'TestJoined.test_throwing' passed (0.003 seconds)
Test Suite 'TestJoined' passed at 2023-06-23 16:48:00.124
Executed 5 tests, with 0 failures (0 unexpected) in 0.015 (0.015) seconds
Test Suite 'TestJoinedBySeparator' started at 2023-06-23 16:48:00.124
Test Case 'TestJoinedBySeparator.test_cancellation' started at 2023-06-23 16:48:00.124
Test Case 'TestJoinedBySeparator.test_cancellation' passed (0.006 seconds)
Test Case 'TestJoinedBySeparator.test_join' started at 2023-06-23 16:48:00.130
Test Case 'TestJoinedBySeparator.test_join' passed (0.005 seconds)
Test Case 'TestJoinedBySeparator.test_join_empty' started at 2023-06-23 16:48:00.135
Test Case 'TestJoinedBySeparator.test_join_empty' passed (0.002 seconds)
Test Case 'TestJoinedBySeparator.test_join_single_sequence' started at 2023-06-23 16:48:00.137
Test Case 'TestJoinedBySeparator.test_join_single_sequence' passed (0.002 seconds)
Test Case 'TestJoinedBySeparator.test_throwing' started at 2023-06-23 16:48:00.139
Test Case 'TestJoinedBySeparator.test_throwing' passed (0.003 seconds)
Test Case 'TestJoinedBySeparator.test_throwing_separator' started at 2023-06-23 16:48:00.142
Test Case 'TestJoinedBySeparator.test_throwing_separator' passed (0.003 seconds)
Test Suite 'TestJoinedBySeparator' passed at 2023-06-23 16:48:00.145
Executed 6 tests, with 0 failures (0 unexpected) in 0.02 (0.02) seconds
Test Suite 'TestLazy' started at 2023-06-23 16:48:00.145
Test Case 'TestLazy.test_lazy_finishes_when_task_is_cancelled' started at 2023-06-23 16:48:00.145
Test Case 'TestLazy.test_lazy_finishes_when_task_is_cancelled' passed (0.004 seconds)
Test Case 'TestLazy.test_lazy_finishes_without_elements_when_source_is_empty' started at 2023-06-23 16:48:00.150
Test Case 'TestLazy.test_lazy_finishes_without_elements_when_source_is_empty' passed (0.002 seconds)
Test Case 'TestLazy.test_lazy_outputs_elements_and_finishes_when_source_is_array' started at 2023-06-23 16:48:00.152
Test Case 'TestLazy.test_lazy_outputs_elements_and_finishes_when_source_is_array' passed (0.001 seconds)
Test Case 'TestLazy.test_lazy_outputs_elements_and_finishes_when_source_is_set' started at 2023-06-23 16:48:00.153
Test Case 'TestLazy.test_lazy_outputs_elements_and_finishes_when_source_is_set' passed (0.002 seconds)
Test Case 'TestLazy.test_lazy_stops_triggering_iterator_events_when_source_is_pastEnd' started at 2023-06-23 16:48:00.155
Test Case 'TestLazy.test_lazy_stops_triggering_iterator_events_when_source_is_pastEnd' passed (0.003 seconds)
Test Case 'TestLazy.test_lazy_triggers_expected_iterator_events_when_source_is_iterated' started at 2023-06-23 16:48:00.158
Test Case 'TestLazy.test_lazy_triggers_expected_iterator_events_when_source_is_iterated' passed (0.002 seconds)
Test Suite 'TestLazy' passed at 2023-06-23 16:48:00.160
Executed 6 tests, with 0 failures (0 unexpected) in 0.014 (0.014) seconds
Test Suite 'TestManualClock' started at 2023-06-23 16:48:00.160
Test Case 'TestManualClock.test_sleep' started at 2023-06-23 16:48:00.160
Test Case 'TestManualClock.test_sleep' passed (0.006 seconds)
Test Case 'TestManualClock.test_sleep_cancel' started at 2023-06-23 16:48:00.166
Test Case 'TestManualClock.test_sleep_cancel' passed (0.003 seconds)
Test Case 'TestManualClock.test_sleep_cancel_before_advance' started at 2023-06-23 16:48:00.169
Test Case 'TestManualClock.test_sleep_cancel_before_advance' passed (0.002 seconds)
Test Suite 'TestManualClock' passed at 2023-06-23 16:48:00.171
Executed 3 tests, with 0 failures (0 unexpected) in 0.011 (0.011) seconds
Test Suite 'TestMerge2' started at 2023-06-23 16:48:00.172
Test Case 'TestMerge2.test_merge_finishes_when_iteration_task_is_cancelled' started at 2023-06-23 16:48:00.172
Test Case 'TestMerge2.test_merge_finishes_when_iteration_task_is_cancelled' passed (0.005 seconds)
Test Case 'TestMerge2.test_merge_makes_sequence_with_elements_from_sources_when_all_have_same_size' started at 2023-06-23 16:48:00.177
Test Case 'TestMerge2.test_merge_makes_sequence_with_elements_from_sources_when_all_have_same_size' passed (0.004 seconds)
Test Case 'TestMerge2.test_merge_makes_sequence_with_elements_from_sources_when_first_is_longer' started at 2023-06-23 16:48:00.181
Test Case 'TestMerge2.test_merge_makes_sequence_with_elements_from_sources_when_first_is_longer' passed (0.004 seconds)
Test Case 'TestMerge2.test_merge_makes_sequence_with_elements_from_sources_when_second_is_longer' started at 2023-06-23 16:48:00.184
Test Case 'TestMerge2.test_merge_makes_sequence_with_elements_from_sources_when_second_is_longer' passed (0.003 seconds)
Test Case 'TestMerge2.test_merge_makes_sequence_with_ordered_elements_when_sources_follow_a_timeline' started at 2023-06-23 16:48:00.187
Test Case 'TestMerge2.test_merge_makes_sequence_with_ordered_elements_when_sources_follow_a_timeline' passed (0.026 seconds)
Test Case 'TestMerge2.test_merge_produces_three_elements_from_first_and_throws_when_first_is_longer_and_throws_after_three_elements' started at 2023-06-23 16:48:00.213
Test Case 'TestMerge2.test_merge_produces_three_elements_from_first_and_throws_when_first_is_longer_and_throws_after_three_elements' passed (0.004 seconds)
Test Case 'TestMerge2.test_merge_produces_three_elements_from_first_and_throws_when_first_is_shorter_and_throws_after_three_elements' started at 2023-06-23 16:48:00.217
Test Case 'TestMerge2.test_merge_produces_three_elements_from_first_and_throws_when_first_is_shorter_and_throws_after_three_elements' passed (0.003 seconds)
Test Case 'TestMerge2.test_merge_produces_three_elements_from_second_and_throws_when_second_is_longer_and_throws_after_three_elements' started at 2023-06-23 16:48:00.221
Test Case 'TestMerge2.test_merge_produces_three_elements_from_second_and_throws_when_second_is_longer_and_throws_after_three_elements' passed (0.004 seconds)
Test Case 'TestMerge2.test_merge_produces_three_elements_from_second_and_throws_when_second_is_shorter_and_throws_after_three_elements' started at 2023-06-23 16:48:00.225
Test Case 'TestMerge2.test_merge_produces_three_elements_from_second_and_throws_when_second_is_shorter_and_throws_after_three_elements' passed (0.004 seconds)
Test Case 'TestMerge2.test_merge_when_cancelled' started at 2023-06-23 16:48:00.229
Test Case 'TestMerge2.test_merge_when_cancelled' passed (0.001 seconds)
Test Suite 'TestMerge2' passed at 2023-06-23 16:48:00.230
	 Executed 10 tests, with 0 failures (0 unexpected) in 0.057 (0.057) seconds
Test Suite 'TestMerge3' started at 2023-06-23 16:48:00.230
Test Case 'TestMerge3.testIteratorDeinitialized_whenFinished' started at 2023-06-23 16:48:00.231
Test Case 'TestMerge3.testIteratorDeinitialized_whenFinished' passed (0.002 seconds)
Test Case 'TestMerge3.testIteratorDeinitialized_whenMerging' started at 2023-06-23 16:48:00.233
Test Case 'TestMerge3.testIteratorDeinitialized_whenMerging' passed (0.002 seconds)
Test Case 'TestMerge3.testIteratorInitialized_whenInitial' started at 2023-06-23 16:48:00.235
Test Case 'TestMerge3.testIteratorInitialized_whenInitial' passed (0.004 seconds)
Test Case 'TestMerge3.test_merge_finishes_when_iteration_task_is_cancelled' started at 2023-06-23 16:48:00.239
Test Case 'TestMerge3.test_merge_finishes_when_iteration_task_is_cancelled' passed (0.006 seconds)
Test Case 'TestMerge3.test_merge_makes_sequence_with_elements_from_sources_when_all_have_same_size' started at 2023-06-23 16:48:00.245
Test Case 'TestMerge3.test_merge_makes_sequence_with_elements_from_sources_when_all_have_same_size' passed (0.004 seconds)
Test Case 'TestMerge3.test_merge_makes_sequence_with_elements_from_sources_when_first_and_second_are_longer' started at 2023-06-23 16:48:00.249
Test Case 'TestMerge3.test_merge_makes_sequence_with_elements_from_sources_when_first_and_second_are_longer' passed (0.004 seconds)
Test Case 'TestMerge3.test_merge_makes_sequence_with_elements_from_sources_when_first_and_third_are_longer' started at 2023-06-23 16:48:00.253
Test Case 'TestMerge3.test_merge_makes_sequence_with_elements_from_sources_when_first_and_third_are_longer' passed (0.004 seconds)
Test Case 'TestMerge3.test_merge_makes_sequence_with_elements_from_sources_when_first_is_longer' started at 2023-06-23 16:48:00.257
Test Case 'TestMerge3.test_merge_makes_sequence_with_elements_from_sources_when_first_is_longer' passed (0.004 seconds)
Test Case 'TestMerge3.test_merge_makes_sequence_with_elements_from_sources_when_second_and_third_are_longer' started at 2023-06-23 16:48:00.261
Test Case 'TestMerge3.test_merge_makes_sequence_with_elements_from_sources_when_second_and_third_are_longer' passed (0.003 seconds)
Test Case 'TestMerge3.test_merge_makes_sequence_with_elements_from_sources_when_second_is_longer' started at 2023-06-23 16:48:00.264
Test Case 'TestMerge3.test_merge_makes_sequence_with_elements_from_sources_when_second_is_longer' passed (0.004 seconds)
Test Case 'TestMerge3.test_merge_makes_sequence_with_elements_from_sources_when_third_is_longer' started at 2023-06-23 16:48:00.268
Test Case 'TestMerge3.test_merge_makes_sequence_with_elements_from_sources_when_third_is_longer' passed (0.004 seconds)
Test Case 'TestMerge3.test_merge_makes_sequence_with_ordered_elements_when_sources_follow_a_timeline' started at 2023-06-23 16:48:00.272
Test Case 'TestMerge3.test_merge_makes_sequence_with_ordered_elements_when_sources_follow_a_timeline' passed (0.03 seconds)
Test Case 'TestMerge3.test_merge_produces_three_elements_from_first_and_throws_when_first_is_longer_and_throws_after_three_elements' started at 2023-06-23 16:48:00.302
Test Case 'TestMerge3.test_merge_produces_three_elements_from_first_and_throws_when_first_is_longer_and_throws_after_three_elements' passed (0.004 seconds)
Test Case 'TestMerge3.test_merge_produces_three_elements_from_first_and_throws_when_first_is_shorter_and_throws_after_three_elements' started at 2023-06-23 16:48:00.306
Test Case 'TestMerge3.test_merge_produces_three_elements_from_first_and_throws_when_first_is_shorter_and_throws_after_three_elements' passed (0.005 seconds)
Test Case 'TestMerge3.test_merge_produces_three_elements_from_second_and_throws_when_second_is_longer_and_throws_after_three_elements' started at 2023-06-23 16:48:00.312
Test Case 'TestMerge3.test_merge_produces_three_elements_from_second_and_throws_when_second_is_longer_and_throws_after_three_elements' passed (0.004 seconds)
Test Case 'TestMerge3.test_merge_produces_three_elements_from_second_and_throws_when_second_is_shorter_and_throws_after_three_elements' started at 2023-06-23 16:48:00.316
Test Case 'TestMerge3.test_merge_produces_three_elements_from_second_and_throws_when_second_is_shorter_and_throws_after_three_elements' passed (0.003 seconds)
Test Case 'TestMerge3.test_merge_produces_three_elements_from_third_and_throws_when_third_is_longer_and_throws_after_three_elements' started at 2023-06-23 16:48:00.319
Test Case 'TestMerge3.test_merge_produces_three_elements_from_third_and_throws_when_third_is_longer_and_throws_after_three_elements' passed (0.004 seconds)
Test Case 'TestMerge3.test_merge_produces_three_elements_from_third_and_throws_when_third_is_shorter_and_throws_after_three_elements' started at 2023-06-23 16:48:00.323
Test Case 'TestMerge3.test_merge_produces_three_elements_from_third_and_throws_when_third_is_shorter_and_throws_after_three_elements' passed (0.004 seconds)
Test Suite 'TestMerge3' passed at 2023-06-23 16:48:00.327
Executed 18 tests, with 0 failures (0 unexpected) in 0.094 (0.094) seconds
Test Suite 'TestRangeReplaceableCollection' started at 2023-06-23 16:48:00.328
Test Case 'TestRangeReplaceableCollection.test_Array' started at 2023-06-23 16:48:00.328
Test Case 'TestRangeReplaceableCollection.test_Array' passed (0.001 seconds)
Test Case 'TestRangeReplaceableCollection.test_ContiguousArray' started at 2023-06-23 16:48:00.329
Test Case 'TestRangeReplaceableCollection.test_ContiguousArray' passed (0.002 seconds)
Test Case 'TestRangeReplaceableCollection.test_Data' started at 2023-06-23 16:48:00.331
Test Case 'TestRangeReplaceableCollection.test_Data' passed (0.004 seconds)
Test Case 'TestRangeReplaceableCollection.test_String' started at 2023-06-23 16:48:00.335
Test Case 'TestRangeReplaceableCollection.test_String' passed (0.002 seconds)
Test Case 'TestRangeReplaceableCollection.test_throwing' started at 2023-06-23 16:48:00.337
Test Case 'TestRangeReplaceableCollection.test_throwing' passed (0.002 seconds)
Test Suite 'TestRangeReplaceableCollection' passed at 2023-06-23 16:48:00.339
	 Executed 5 tests, with 0 failures (0 unexpected) in 0.011 (0.011) seconds
Test Suite 'TestReductions' started at 2023-06-23 16:48:00.339
Test Case 'TestReductions.test_cancellation' started at 2023-06-23 16:48:00.339
Test Case 'TestReductions.test_cancellation' passed (0.004 seconds)
Test Case 'TestReductions.test_inclusive_reductions' started at 2023-06-23 16:48:00.343
Test Case 'TestReductions.test_inclusive_reductions' passed (0.002 seconds)
Test Case 'TestReductions.test_reductions' started at 2023-06-23 16:48:00.346
Test Case 'TestReductions.test_reductions' passed (0.003 seconds)
Test Case 'TestReductions.test_reductions_into' started at 2023-06-23 16:48:00.349
Test Case 'TestReductions.test_reductions_into' passed (0.002 seconds)
Test Case 'TestReductions.test_throw_upstream_inclusive_reductions' started at 2023-06-23 16:48:00.351
Test Case 'TestReductions.test_throw_upstream_inclusive_reductions' passed (0.002 seconds)
Test Case 'TestReductions.test_throw_upstream_inclusive_reductions_throws' started at 2023-06-23 16:48:00.353
Test Case 'TestReductions.test_throw_upstream_inclusive_reductions_throws' passed (0.003 seconds)
Test Case 'TestReductions.test_throw_upstream_reductions' started at 2023-06-23 16:48:00.356
Test Case 'TestReductions.test_throw_upstream_reductions' passed (0.002 seconds)
Test Case 'TestReductions.test_throw_upstream_reductions_throws' started at 2023-06-23 16:48:00.358
Test Case 'TestReductions.test_throw_upstream_reductions_throws' passed (0.003 seconds)
Test Case 'TestReductions.test_throwing_inclusive_reductions' started at 2023-06-23 16:48:00.362
Test Case 'TestReductions.test_throwing_inclusive_reductions' passed (0.002 seconds)
Test Case 'TestReductions.test_throwing_reductions' started at 2023-06-23 16:48:00.363
Test Case 'TestReductions.test_throwing_reductions' passed (0.002 seconds)
Test Case 'TestReductions.test_throwing_reductions_into' started at 2023-06-23 16:48:00.365
Test Case 'TestReductions.test_throwing_reductions_into' passed (0.002 seconds)
Test Case 'TestReductions.test_throwing_reductions_into_throws' started at 2023-06-23 16:48:00.367
Test Case 'TestReductions.test_throwing_reductions_into_throws' passed (0.002 seconds)
Test Suite 'TestReductions' passed at 2023-06-23 16:48:00.369
Executed 12 tests, with 0 failures (0 unexpected) in 0.029 (0.029) seconds
Test Suite 'TestRemoveDuplicates' started at 2023-06-23 16:48:00.369
Test Case 'TestRemoveDuplicates.test_removeDuplicates' started at 2023-06-23 16:48:00.370
Test Case 'TestRemoveDuplicates.test_removeDuplicates' passed (0.003 seconds)
Test Case 'TestRemoveDuplicates.test_removeDuplicates_cancellation' started at 2023-06-23 16:48:00.373
Test Case 'TestRemoveDuplicates.test_removeDuplicates_cancellation' passed (0.003 seconds)
Test Case 'TestRemoveDuplicates.test_removeDuplicates_with_closure' started at 2023-06-23 16:48:00.375
Test Case 'TestRemoveDuplicates.test_removeDuplicates_with_closure' passed (0.003 seconds)
Test Case 'TestRemoveDuplicates.test_removeDuplicates_with_throwing_closure' started at 2023-06-23 16:48:00.378
Test Case 'TestRemoveDuplicates.test_removeDuplicates_with_throwing_closure' passed (0.003 seconds)
Test Case 'TestRemoveDuplicates.test_removeDuplicates_with_throwing_upstream' started at 2023-06-23 16:48:00.382
Test Case 'TestRemoveDuplicates.test_removeDuplicates_with_throwing_upstream' passed (0.002 seconds)
Test Suite 'TestRemoveDuplicates' passed at 2023-06-23 16:48:00.383
Executed 5 tests, with 0 failures (0 unexpected) in 0.013 (0.013) seconds
Test Suite 'TestSetAlgebra' started at 2023-06-23 16:48:00.384
Test Case 'TestSetAlgebra.test_IndexSet' started at 2023-06-23 16:48:00.384
Test Case 'TestSetAlgebra.test_IndexSet' passed (0.006 seconds)
Test Case 'TestSetAlgebra.test_Set' started at 2023-06-23 16:48:00.390
Test Case 'TestSetAlgebra.test_Set' passed (0.001 seconds)
Test Case 'TestSetAlgebra.test_Set_duplicate' started at 2023-06-23 16:48:00.391
Test Case 'TestSetAlgebra.test_Set_duplicate' passed (0.001 seconds)
Test Case 'TestSetAlgebra.test_throwing' started at 2023-06-23 16:48:00.393
Test Case 'TestSetAlgebra.test_throwing' passed (0.002 seconds)
Test Suite 'TestSetAlgebra' passed at 2023-06-23 16:48:00.395
Executed 4 tests, with 0 failures (0 unexpected) in 0.01 (0.01) seconds
Test Suite 'TestThrottle' started at 2023-06-23 16:48:00.395
Test Case 'TestThrottle.test_emission_2_rate_1' started at 2023-06-23 16:48:00.395
Test Case 'TestThrottle.test_emission_2_rate_1' passed (0.02 seconds)
Test Case 'TestThrottle.test_emission_2_rate_2' started at 2023-06-23 16:48:00.415
Test Case 'TestThrottle.test_emission_2_rate_2' passed (0.015 seconds)
Test Case 'TestThrottle.test_emission_2_rate_3' started at 2023-06-23 16:48:00.430
Test Case 'TestThrottle.test_emission_2_rate_3' passed (0.014 seconds)
Test Case 'TestThrottle.test_emission_3_rate_2' started at 2023-06-23 16:48:00.445
Test Case 'TestThrottle.test_emission_3_rate_2' passed (0.013 seconds)
Test Case 'TestThrottle.test_rate_0' started at 2023-06-23 16:48:00.458
Test Case 'TestThrottle.test_rate_0' passed (0.014 seconds)
Test Case 'TestThrottle.test_rate_0_leading_edge' started at 2023-06-23 16:48:00.472
Test Case 'TestThrottle.test_rate_0_leading_edge' passed (0.015 seconds)
Test Case 'TestThrottle.test_rate_1' started at 2023-06-23 16:48:00.487
Test Case 'TestThrottle.test_rate_1' passed (0.015 seconds)
Test Case 'TestThrottle.test_rate_1_leading_edge' started at 2023-06-23 16:48:00.502
Test Case 'TestThrottle.test_rate_1_leading_edge' passed (0.014 seconds)
Test Case 'TestThrottle.test_rate_2' started at 2023-06-23 16:48:00.517
Test Case 'TestThrottle.test_rate_2' passed (0.014 seconds)
Test Case 'TestThrottle.test_rate_2_leading_edge' started at 2023-06-23 16:48:00.531
Test Case 'TestThrottle.test_rate_2_leading_edge' passed (0.014 seconds)
Test Case 'TestThrottle.test_rate_3' started at 2023-06-23 16:48:00.545
Test Case 'TestThrottle.test_rate_3' passed (0.014 seconds)
Test Case 'TestThrottle.test_rate_3_leading_edge' started at 2023-06-23 16:48:00.559
Test Case 'TestThrottle.test_rate_3_leading_edge' passed (0.014 seconds)
Test Case 'TestThrottle.test_throwing' started at 2023-06-23 16:48:00.573
Test Case 'TestThrottle.test_throwing' passed (0.01 seconds)
Test Case 'TestThrottle.test_throwing_leading_edge' started at 2023-06-23 16:48:00.583
Test Case 'TestThrottle.test_throwing_leading_edge' passed (0.011 seconds)
Test Suite 'TestThrottle' passed at 2023-06-23 16:48:00.594
Executed 14 tests, with 0 failures (0 unexpected) in 0.197 (0.197) seconds
Test Suite 'TestThrowingChannel' started at 2023-06-23 16:48:00.594
Test Case 'TestThrowingChannel.test_asyncThrowingChannel_delivers_elements_when_several_producers_and_several_consumers' started at 2023-06-23 16:48:00.595
Test Case 'TestThrowingChannel.test_asyncThrowingChannel_delivers_elements_when_several_producers_and_several_consumers' passed (0.007 seconds)
Test Case 'TestThrowingChannel.test_asyncThrowingChannel_resumes_consumer_when_fail_is_called' started at 2023-06-23 16:48:00.601
Test Case 'TestThrowingChannel.test_asyncThrowingChannel_resumes_consumer_when_fail_is_called' passed (0.003 seconds)
Test Case 'TestThrowingChannel.test_asyncThrowingChannel_resumes_consumer_when_task_is_cancelled' started at 2023-06-23 16:48:00.604
Test Case 'TestThrowingChannel.test_asyncThrowingChannel_resumes_consumer_when_task_is_cancelled' passed (0.003 seconds)
Test Case 'TestThrowingChannel.test_asyncThrowingChannel_resumes_consumer_with_error_when_already_failed' started at 2023-06-23 16:48:00.607
Test Case 'TestThrowingChannel.test_asyncThrowingChannel_resumes_consumer_with_error_when_already_failed' passed (0.002 seconds)
Test Case 'TestThrowingChannel.test_asyncThrowingChannel_resumes_consumers_when_fail_is_called' started at 2023-06-23 16:48:00.609
Test Case 'TestThrowingChannel.test_asyncThrowingChannel_resumes_consumers_when_fail_is_called' passed (0.002 seconds)
Test Case 'TestThrowingChannel.test_asyncThrowingChannel_resumes_consumers_when_finish_is_called' started at 2023-06-23 16:48:00.611
Test Case 'TestThrowingChannel.test_asyncThrowingChannel_resumes_consumers_when_finish_is_called' passed (0.003 seconds)
Test Case 'TestThrowingChannel.test_asyncThrowingChannel_resumes_producer_when_task_is_cancelled' started at 2023-06-23 16:48:00.614
Test Case 'TestThrowingChannel.test_asyncThrowingChannel_resumes_producer_when_task_is_cancelled' passed (0.003 seconds)
Test Case 'TestThrowingChannel.test_asyncThrowingChannel_resumes_producers_and_discards_additional_elements_when_fail_is_called' started at 2023-06-23 16:48:00.617
Test Case 'TestThrowingChannel.test_asyncThrowingChannel_resumes_producers_and_discards_additional_elements_when_fail_is_called' passed (0.002 seconds)
Test Case 'TestThrowingChannel.test_asyncThrowingChannel_resumes_producers_and_discards_additional_elements_when_finish_is_called' started at 2023-06-23 16:48:00.619
Test Case 'TestThrowingChannel.test_asyncThrowingChannel_resumes_producers_and_discards_additional_elements_when_finish_is_called' passed (0.002 seconds)
Test Suite 'TestThrowingChannel' passed at 2023-06-23 16:48:00.622
Executed 9 tests, with 0 failures (0 unexpected) in 0.026 (0.026) seconds
Test Suite 'TestTimer' started at 2023-06-23 16:48:00.622
Test Case 'TestTimer.test_tick1' started at 2023-06-23 16:48:00.622
Test Case 'TestTimer.test_tick1' passed (0.01 seconds)
Test Case 'TestTimer.test_tick2' started at 2023-06-23 16:48:00.632
Test Case 'TestTimer.test_tick2' passed (0.007 seconds)
Test Case 'TestTimer.test_tick2_event_skew3' started at 2023-06-23 16:48:00.639
Test Case 'TestTimer.test_tick2_event_skew3' passed (0.009 seconds)
Test Case 'TestTimer.test_tick3' started at 2023-06-23 16:48:00.648
Test Case 'TestTimer.test_tick3' passed (0.007 seconds)
Test Suite 'TestTimer' passed at 2023-06-23 16:48:00.655
Executed 4 tests, with 0 failures (0 unexpected) in 0.033 (0.033) seconds
Test Suite 'TestValidationDiagram' started at 2023-06-23 16:48:00.655
Test Case 'TestValidationDiagram.test_cancel_event' started at 2023-06-23 16:48:00.655
Test Case 'TestValidationDiagram.test_cancel_event' passed (0.006 seconds)
Test Case 'TestValidationDiagram.test_delayNext' started at 2023-06-23 16:48:00.662
Test Case 'TestValidationDiagram.test_delayNext' passed (0.007 seconds)
Test Case 'TestValidationDiagram.test_delayNext_initialDelay' started at 2023-06-23 16:48:00.669
Test Case 'TestValidationDiagram.test_delayNext_initialDelay' passed (0.006 seconds)
Test Case 'TestValidationDiagram.test_delayNext_into_emptyTick' started at 2023-06-23 16:48:00.675
Test Case 'TestValidationDiagram.test_delayNext_into_emptyTick' passed (0.01 seconds)
Test Case 'TestValidationDiagram.test_diagram' started at 2023-06-23 16:48:00.685
Test Case 'TestValidationDiagram.test_diagram' passed (0.012 seconds)
Test Case 'TestValidationDiagram.test_diagram_emoji' started at 2023-06-23 16:48:00.697
Test Case 'TestValidationDiagram.test_diagram_emoji' passed (0.008 seconds)
Test Case 'TestValidationDiagram.test_diagram_failure_error_for_finish' started at 2023-06-23 16:48:00.705
Test Case 'TestValidationDiagram.test_diagram_failure_error_for_finish' passed (0.011 seconds)
Test Case 'TestValidationDiagram.test_diagram_failure_error_for_value' started at 2023-06-23 16:48:00.716
Test Case 'TestValidationDiagram.test_diagram_failure_error_for_value' passed (0.008 seconds)
Test Case 'TestValidationDiagram.test_diagram_failure_expected_failure' started at 2023-06-23 16:48:00.724
Test Case 'TestValidationDiagram.test_diagram_failure_expected_failure' passed (0.008 seconds)
Test Case 'TestValidationDiagram.test_diagram_failure_expected_value' started at 2023-06-23 16:48:00.732
Test Case 'TestValidationDiagram.test_diagram_failure_expected_value' passed (0.007 seconds)
Test Case 'TestValidationDiagram.test_diagram_failure_finish_for_error' started at 2023-06-23 16:48:00.739
Test Case 'TestValidationDiagram.test_diagram_failure_finish_for_error' passed (0.008 seconds)
Test Case 'TestValidationDiagram.test_diagram_failure_finish_for_value' started at 2023-06-23 16:48:00.747
Test Case 'TestValidationDiagram.test_diagram_failure_finish_for_value' passed (0.007 seconds)
Test Case 'TestValidationDiagram.test_diagram_failure_mismatch_value' started at 2023-06-23 16:48:00.754
Test Case 'TestValidationDiagram.test_diagram_failure_mismatch_value' passed (0.009 seconds)
Test Case 'TestValidationDiagram.test_diagram_failure_unexpected_failure' started at 2023-06-23 16:48:00.764
Test Case 'TestValidationDiagram.test_diagram_failure_unexpected_failure' passed (0.007 seconds)
Test Case 'TestValidationDiagram.test_diagram_failure_unexpected_value' started at 2023-06-23 16:48:00.771
Test Case 'TestValidationDiagram.test_diagram_failure_unexpected_value' passed (0.009 seconds)
Test Case 'TestValidationDiagram.test_diagram_failure_value_for_error' started at 2023-06-23 16:48:00.780
Test Case 'TestValidationDiagram.test_diagram_failure_value_for_error' passed (0.009 seconds)
Test Case 'TestValidationDiagram.test_diagram_failure_value_for_finish' started at 2023-06-23 16:48:00.790
Test Case 'TestValidationDiagram.test_diagram_failure_value_for_finish' passed (0.01 seconds)
Test Case 'TestValidationDiagram.test_diagram_grouping_source' started at 2023-06-23 16:48:00.799
Test Case 'TestValidationDiagram.test_diagram_grouping_source' passed (0.007 seconds)
Test Case 'TestValidationDiagram.test_diagram_groups_of_one' started at 2023-06-23 16:48:00.807
Test Case 'TestValidationDiagram.test_diagram_groups_of_one' passed (0.007 seconds)
Test Case 'TestValidationDiagram.test_diagram_parse_failure_nested_group' started at 2023-06-23 16:48:00.814
Test Case 'TestValidationDiagram.test_diagram_parse_failure_nested_group' passed (0.002 seconds)
Test Case 'TestValidationDiagram.test_diagram_parse_failure_nested_group_input' started at 2023-06-23 16:48:00.816
Test Case 'TestValidationDiagram.test_diagram_parse_failure_nested_group_input' passed (0.001 seconds)
Test Case 'TestValidationDiagram.test_diagram_parse_failure_step_in_group' started at 2023-06-23 16:48:00.817
Test Case 'TestValidationDiagram.test_diagram_parse_failure_step_in_group' passed (0.001 seconds)
Test Case 'TestValidationDiagram.test_diagram_parse_failure_step_in_group_input' started at 2023-06-23 16:48:00.819
Test Case 'TestValidationDiagram.test_diagram_parse_failure_step_in_group_input' passed (0.001 seconds)
Test Case 'TestValidationDiagram.test_diagram_parse_failure_unbalanced_group' started at 2023-06-23 16:48:00.820
Test Case 'TestValidationDiagram.test_diagram_parse_failure_unbalanced_group' passed (0.001 seconds)
Test Case 'TestValidationDiagram.test_diagram_parse_failure_unbalanced_group_input' started at 2023-06-23 16:48:00.821
Test Case 'TestValidationDiagram.test_diagram_parse_failure_unbalanced_group_input' passed (0.001 seconds)
Test Case 'TestValidationDiagram.test_diagram_space_noop' started at 2023-06-23 16:48:00.823
Test Case 'TestValidationDiagram.test_diagram_space_noop' passed (0.009 seconds)
Test Case 'TestValidationDiagram.test_diagram_specification_produce_past_end' started at 2023-06-23 16:48:00.832
Test Case 'TestValidationDiagram.test_diagram_specification_produce_past_end' passed (0.009 seconds)
Test Case 'TestValidationDiagram.test_diagram_specification_throw_past_end' started at 2023-06-23 16:48:00.841
Test Case 'TestValidationDiagram.test_diagram_specification_throw_past_end' passed (0.007 seconds)
Test Case 'TestValidationDiagram.test_diagram_string_dsl_contents' started at 2023-06-23 16:48:00.849
Test Case 'TestValidationDiagram.test_diagram_string_dsl_contents' passed (0.006 seconds)
Test Case 'TestValidationDiagram.test_diagram_string_input' started at 2023-06-23 16:48:00.855
Test Case 'TestValidationDiagram.test_diagram_string_input' passed (0.007 seconds)
Test Case 'TestValidationDiagram.test_diagram_string_input_expectation' started at 2023-06-23 16:48:00.861
Test Case 'TestValidationDiagram.test_diagram_string_input_expectation' passed (0.006 seconds)
Test Case 'TestValidationDiagram.test_values_one_at_a_time_after_delay' started at 2023-06-23 16:48:00.867
Test Case 'TestValidationDiagram.test_values_one_at_a_time_after_delay' passed (0.008 seconds)
Test Suite 'TestValidationDiagram' passed at 2023-06-23 16:48:00.875
Executed 32 tests, with 0 failures (0 unexpected) in 0.216 (0.216) seconds
Test Suite 'TestValidator' started at 2023-06-23 16:48:00.875
Test Case 'TestValidator.test_gate' started at 2023-06-23 16:48:00.875
Test Case 'TestValidator.test_gate' passed (0.002 seconds)
Test Case 'TestValidator.test_gatedSequence' started at 2023-06-23 16:48:00.878
Test Case 'TestValidator.test_gatedSequence' passed (0.005 seconds)
Test Case 'TestValidator.test_gatedSequence_throwing' started at 2023-06-23 16:48:00.883
Test Case 'TestValidator.test_gatedSequence_throwing' passed (0.004 seconds)
Test Case 'TestValidator.test_validator' started at 2023-06-23 16:48:00.887
Test Case 'TestValidator.test_validator' passed (0.003 seconds)
Test Suite 'TestValidator' passed at 2023-06-23 16:48:00.891
Executed 4 tests, with 0 failures (0 unexpected) in 0.015 (0.015) seconds
Test Suite 'TestZip2' started at 2023-06-23 16:48:00.891
Test Case 'TestZip2.test_zip_finishes_when_iteration_task_is_cancelled' started at 2023-06-23 16:48:00.891
Test Case 'TestZip2.test_zip_finishes_when_iteration_task_is_cancelled' passed (0.021 seconds)
Test Case 'TestZip2.test_zip_makes_sequence_equivalent_to_synchronous_zip_when_all_sequences_have_same_size' started at 2023-06-23 16:48:00.912
Test Case 'TestZip2.test_zip_makes_sequence_equivalent_to_synchronous_zip_when_all_sequences_have_same_size' passed (0.006 seconds)
Test Case 'TestZip2.test_zip_makes_sequence_equivalent_to_synchronous_zip_when_first_is_longer' started at 2023-06-23 16:48:00.918
Test Case 'TestZip2.test_zip_makes_sequence_equivalent_to_synchronous_zip_when_first_is_longer' passed (0.004 seconds)
Test Case 'TestZip2.test_zip_makes_sequence_equivalent_to_synchronous_zip_when_second_is_longer' started at 2023-06-23 16:48:00.923
Test Case 'TestZip2.test_zip_makes_sequence_equivalent_to_synchronous_zip_when_second_is_longer' passed (0.003 seconds)
Test Case 'TestZip2.test_zip_produces_nil_next_element_when_iteration_is_finished_and_all_sequences_have_same_size' started at 2023-06-23 16:48:00.926
Test Case 'TestZip2.test_zip_produces_nil_next_element_when_iteration_is_finished_and_all_sequences_have_same_size' passed (0.004 seconds)
Test Case 'TestZip2.test_zip_produces_nil_next_element_when_iteration_is_finished_and_first_is_longer' started at 2023-06-23 16:48:00.929
Test Case 'TestZip2.test_zip_produces_nil_next_element_when_iteration_is_finished_and_first_is_longer' passed (0.004 seconds)
Test Case 'TestZip2.test_zip_produces_nil_next_element_when_iteration_is_finished_and_second_is_longer' started at 2023-06-23 16:48:00.934
Test Case 'TestZip2.test_zip_produces_nil_next_element_when_iteration_is_finished_and_second_is_longer' passed (0.004 seconds)
Test Case 'TestZip2.test_zip_produces_one_element_and_throws_when_first_produces_one_element_and_throws' started at 2023-06-23 16:48:00.937
Test Case 'TestZip2.test_zip_produces_one_element_and_throws_when_first_produces_one_element_and_throws' passed (0.004 seconds)
Test Case 'TestZip2.test_zip_produces_one_element_and_throws_when_second_produces_one_element_and_throws' started at 2023-06-23 16:48:00.941
Test Case 'TestZip2.test_zip_produces_one_element_and_throws_when_second_produces_one_element_and_throws' passed (0.004 seconds)
Test Case 'TestZip2.test_zip_when_cancelled' started at 2023-06-23 16:48:00.945
Test Case 'TestZip2.test_zip_when_cancelled' passed (0.001 seconds)
Test Suite 'TestZip2' passed at 2023-06-23 16:48:00.946
Executed 10 tests, with 0 failures (0 unexpected) in 0.054 (0.054) seconds
Test Suite 'TestZip3' started at 2023-06-23 16:48:00.947
Test Case 'TestZip3.test_zip_finishes_when_iteration_task_is_cancelled' started at 2023-06-23 16:48:00.947
Test Case 'TestZip3.test_zip_finishes_when_iteration_task_is_cancelled' passed (0.007 seconds)
Test Case 'TestZip3.test_zip_makes_sequence_equivalent_to_synchronous_zip_when_all_sequences_have_same_size' started at 2023-06-23 16:48:00.954
Test Case 'TestZip3.test_zip_makes_sequence_equivalent_to_synchronous_zip_when_all_sequences_have_same_size' passed (0.005 seconds)
Test Case 'TestZip3.test_zip_makes_sequence_equivalent_to_synchronous_zip_when_first_is_longer' started at 2023-06-23 16:48:00.960
Test Case 'TestZip3.test_zip_makes_sequence_equivalent_to_synchronous_zip_when_first_is_longer' passed (0.004 seconds)
Test Case 'TestZip3.test_zip_makes_sequence_equivalent_to_synchronous_zip_when_second_is_longer' started at 2023-06-23 16:48:00.964
Test Case 'TestZip3.test_zip_makes_sequence_equivalent_to_synchronous_zip_when_second_is_longer' passed (0.004 seconds)
Test Case 'TestZip3.test_zip_makes_sequence_equivalent_to_synchronous_zip_when_third_is_longer' started at 2023-06-23 16:48:00.968
Test Case 'TestZip3.test_zip_makes_sequence_equivalent_to_synchronous_zip_when_third_is_longer' passed (0.004 seconds)
Test Case 'TestZip3.test_zip_produces_nil_next_element_when_iteration_is_finished_and_all_sequences_have_same_size' started at 2023-06-23 16:48:00.972
Test Case 'TestZip3.test_zip_produces_nil_next_element_when_iteration_is_finished_and_all_sequences_have_same_size' passed (0.005 seconds)
Test Case 'TestZip3.test_zip_produces_nil_next_element_when_iteration_is_finished_and_first_is_longer' started at 2023-06-23 16:48:00.977
Test Case 'TestZip3.test_zip_produces_nil_next_element_when_iteration_is_finished_and_first_is_longer' passed (0.004 seconds)
Test Case 'TestZip3.test_zip_produces_nil_next_element_when_iteration_is_finished_and_second_is_longer' started at 2023-06-23 16:48:00.982
Test Case 'TestZip3.test_zip_produces_nil_next_element_when_iteration_is_finished_and_second_is_longer' passed (0.004 seconds)
Test Case 'TestZip3.test_zip_produces_nil_next_element_when_iteration_is_finished_and_third_is_longer' started at 2023-06-23 16:48:00.986
Test Case 'TestZip3.test_zip_produces_nil_next_element_when_iteration_is_finished_and_third_is_longer' passed (0.005 seconds)
Test Case 'TestZip3.test_zip_produces_one_element_and_throws_when_first_produces_one_element_and_throws' started at 2023-06-23 16:48:00.991
Test Case 'TestZip3.test_zip_produces_one_element_and_throws_when_first_produces_one_element_and_throws' passed (0.004 seconds)
Test Case 'TestZip3.test_zip_produces_one_element_and_throws_when_second_produces_one_element_and_throws' started at 2023-06-23 16:48:00.995
Test Case 'TestZip3.test_zip_produces_one_element_and_throws_when_second_produces_one_element_and_throws' passed (0.004 seconds)
Test Case 'TestZip3.test_zip_produces_one_element_and_throws_when_third_produces_one_element_and_throws' started at 2023-06-23 16:48:01.000
Test Case 'TestZip3.test_zip_produces_one_element_and_throws_when_third_produces_one_element_and_throws' passed (0.004 seconds)
Test Suite 'TestZip3' passed at 2023-06-23 16:48:01.004
Executed 12 tests, with 0 failures (0 unexpected) in 0.055 (0.055) seconds
Test Suite 'debug.xctest' passed at 2023-06-23 16:48:01.004
Executed 265 tests, with 0 failures (0 unexpected) in 2.181 (2.181) seconds
Test Suite 'All tests' passed at 2023-06-23 16:48:01.005
Executed 265 tests, with 0 failures (0 unexpected) in 2.181 (2.181) seconds
```
</details>

Thanks in advance!