### PR TITLE
Merge provides all elements from the subsequences on cancellation

### DIFF
--- a/Sources/AsyncAlgorithms/Merge/MergeStorage.swift
+++ b/Sources/AsyncAlgorithms/Merge/MergeStorage.swift
@@ -128,12 +128,7 @@ final class MergeStorage<
 
                 downstreamContinuation.resume(returning: nil)
 
-            case let .cancelTaskAndUpstreamContinuations(
-                task,
-                upstreamContinuations
-            ):
-                upstreamContinuations.forEach { $0.resume(throwing: CancellationError()) }
-
+            case let .cancelTask(task):
                 task.cancel()
 
             case .none:
@@ -262,8 +257,8 @@ final class MergeStorage<
                         task,
                         upstreamContinuations
                     ):
-                        upstreamContinuations.forEach { $0.resume(throwing: CancellationError()) }
                         task.cancel()
+                        upstreamContinuations.forEach { $0.resume() }
 
                         downstreamContinuation.resume(returning: nil)
 
@@ -273,8 +268,8 @@ final class MergeStorage<
                         task,
                         upstreamContinuations
                     ):
-                        upstreamContinuations.forEach { $0.resume(throwing: CancellationError()) }
                         task.cancel()
+                        upstreamContinuations.forEach { $0.resume() }
 
                         break loop
                     case .none:


### PR DESCRIPTION
On cancellation, merge currently does not yield all elements. This leads to situations in which the final elements of AsyncStreams are not forwarded to the user. This patch ensures, that only the underlying Task is cancelled and all subsequences' elements are forwarded to the user.