### PR TITLE
Add `branch: "main"` to SwiftPM section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ To use the `AsyncAlgorithms` library in a SwiftPM project,
 add the following line to the dependencies in your `Package.swift` file:
 
 ```swift
-.package(url: "https://github.com/apple/swift-async-algorithms"),
+.package(url: "https://github.com/apple/swift-async-algorithms", branch: "main"),
 ```
 
 Include `"AsyncAlgorithms"` as a dependency for your executable target:


### PR DESCRIPTION
In the _Adding Swift Async Algorithms as a Dependency_ section, a SwiftPM dependency requirement, like `branch: "main"`, was missing.