### PR TITLE
Fix more `Sendable` warnings and flaky test

### DIFF
--- a/Package@swift-5.7.swift
+++ b/Package@swift-5.7.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 5.6
 
 import PackageDescription
 
@@ -20,33 +20,18 @@ let package = Package(
   targets: [
     .target(
       name: "AsyncAlgorithms",
-      dependencies: [.product(name: "Collections", package: "swift-collections")],
-      swiftSettings: [
-          .enableExperimentalFeature("StrictConcurrency=complete"),
-      ]
+      dependencies: [.product(name: "Collections", package: "swift-collections")]
     ),
     .target(
       name: "AsyncSequenceValidation",
-      dependencies: ["_CAsyncSequenceValidationSupport", "AsyncAlgorithms"],
-      swiftSettings: [
-          .enableExperimentalFeature("StrictConcurrency=complete"),
-      ]
-    ),
+      dependencies: ["_CAsyncSequenceValidationSupport", "AsyncAlgorithms"]),
     .systemLibrary(name: "_CAsyncSequenceValidationSupport"),
     .target(
       name: "AsyncAlgorithms_XCTest",
-      dependencies: ["AsyncAlgorithms", "AsyncSequenceValidation"],
-      swiftSettings: [
-          .enableExperimentalFeature("StrictConcurrency=complete"),
-      ]
-    ),
+      dependencies: ["AsyncAlgorithms", "AsyncSequenceValidation"]),
     .testTarget(
       name: "AsyncAlgorithmsTests",
-      dependencies: ["AsyncAlgorithms", "AsyncSequenceValidation", "AsyncAlgorithms_XCTest"],
-      swiftSettings: [
-          .enableExperimentalFeature("StrictConcurrency=complete"),
-      ]
-    ),
+      dependencies: ["AsyncAlgorithms", "AsyncSequenceValidation", "AsyncAlgorithms_XCTest"]),
   ]
 )
 

--- a/Sources/AsyncAlgorithms/Merge/MergeStorage.swift
+++ b/Sources/AsyncAlgorithms/Merge/MergeStorage.swift
@@ -198,7 +198,7 @@ final class MergeStorage<
     private func iterateAsyncSequence<AsyncSequence: _Concurrency.AsyncSequence>(
         _ base: AsyncSequence,
         in taskGroup: inout ThrowingTaskGroup<Void, Error>
-    ) where AsyncSequence.Element == Base1.Element {
+    ) where AsyncSequence.Element == Base1.Element, AsyncSequence: Sendable {
         // For each upstream sequence we are adding a child task that
         // is consuming the upstream sequence
         taskGroup.addTask {

--- a/Tests/AsyncAlgorithmsTests/Interspersed/TestInterspersed.swift
+++ b/Tests/AsyncAlgorithmsTests/Interspersed/TestInterspersed.swift
@@ -166,10 +166,6 @@ final class TestInterspersed: XCTestCase {
 
                 while let _ = await iterator.next() {}
 
-                let pastEnd = await iterator.next()
-                XCTAssertNil(pastEnd)
-
-                // Information the parent task that we finished consuming
                 await lockStepChannel.send(())
             }
 
@@ -179,8 +175,7 @@ final class TestInterspersed: XCTestCase {
             // Now we cancel the child
             group.cancelAll()
 
-            // Waiting until the child task finished consuming
-            _ = await lockStepChannel.first { _ in true }
+            await group.waitForAll()
         }
     }
 }

--- a/Tests/AsyncAlgorithmsTests/Performance/ThroughputMeasurement.swift
+++ b/Tests/AsyncAlgorithmsTests/Performance/ThroughputMeasurement.swift
@@ -56,7 +56,7 @@ final class _ThroughputMetric: NSObject, XCTMetric, @unchecked Sendable {
 }
 
 extension XCTestCase {
-  public func measureChannelThroughput<Output>(output: @escaping @autoclosure () -> Output) async {
+  public func measureChannelThroughput<Output: Sendable>(output: @Sendable @escaping @autoclosure () -> Output) async {
     let metric = _ThroughputMetric()
     let sampleTime: Double = 0.1
 
@@ -85,7 +85,7 @@ extension XCTestCase {
     }
   }
 
-  public func measureThrowingChannelThroughput<Output>(output: @escaping @autoclosure () -> Output) async {
+  public func measureThrowingChannelThroughput<Output: Sendable>(output: @Sendable @escaping @autoclosure () -> Output) async {
     let metric = _ThroughputMetric()
     let sampleTime: Double = 0.1
 

--- a/Tests/AsyncAlgorithmsTests/TestChunk.swift
+++ b/Tests/AsyncAlgorithmsTests/TestChunk.swift
@@ -13,10 +13,12 @@ import XCTest
 import AsyncSequenceValidation
 import AsyncAlgorithms
 
+@Sendable
 func sumCharacters(_ array: [String]) -> String {
   return "\(array.reduce(into: 0) { $0 = $0 + Int($1)! })"
 }
 
+@Sendable
 func concatCharacters(_ array: [String]) -> String {
   return array.joined()
 }


### PR DESCRIPTION
# Motivation
We still had some `Sendable` warnings left under strict Concurrency checking.

# Modification
This PR fixes a bunch of `Sendable` warnings but we still have some left in the validation tests. Additionally, I fixed a flaky test.