### PR TITLE
Ensure tests work in deployments that host as swift 5.7

### DIFF
--- a/Tests/AsyncAlgorithmsTests/Performance/TestThroughput.swift
+++ b/Tests/AsyncAlgorithmsTests/Performance/TestThroughput.swift
@@ -90,11 +90,12 @@ final class TestThroughput: XCTestCase {
       zip($0, $1, $2)
     }
   }
-  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
   func test_debounce() async {
+    if #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) {
       await measureSequenceThroughput(source: (1...).async) {
-          $0.debounce(for: .zero, clock: ContinuousClock())
+        $0.debounce(for: .zero, clock: ContinuousClock())
       }
+    }
   }
 }
 #endif


### PR DESCRIPTION
Validating swift 5.7 build environments revealed a few minor issues with new testing adoption - this adds in an async shim for waiting for expectations and corrects a mistyped availability in the tests.