### PR TITLE
Make `main` build with 5.7 and 5.8 again

### DIFF
--- a/Sources/AsyncAlgorithms_XCTest/ValidationTest.swift
+++ b/Sources/AsyncAlgorithms_XCTest/ValidationTest.swift
@@ -23,7 +23,8 @@ extension XCTestCase {
     XCTFail(description, file: location.file, line: location.line)
 #endif
   }
-  
+
+  @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
   func validate<Test: AsyncSequenceValidationTest, Theme: AsyncSequenceValidationTheme>(theme: Theme, expectedFailures: Set<String>, @AsyncSequenceValidationDiagram _ build: (AsyncSequenceValidationDiagram) -> Test, file: StaticString = #file, line: UInt = #line) {
     var expectations = expectedFailures
     var result: AsyncSequenceValidationDiagram.ExpectationResult?
@@ -61,15 +62,18 @@ extension XCTestCase {
       XCTFail("Expected failure: \(expectation) did not occur.", file: file, line: line)
     }
   }
-  
+
+  @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
   func validate<Test: AsyncSequenceValidationTest>(expectedFailures: Set<String>, @AsyncSequenceValidationDiagram _ build: (AsyncSequenceValidationDiagram) -> Test, file: StaticString = #file, line: UInt = #line) {
     validate(theme: .ascii, expectedFailures: expectedFailures, build, file: file, line: line)
   }
-  
+
+  @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
   public func validate<Test: AsyncSequenceValidationTest, Theme: AsyncSequenceValidationTheme>(theme: Theme, @AsyncSequenceValidationDiagram _ build: (AsyncSequenceValidationDiagram) -> Test, file: StaticString = #file, line: UInt = #line) {
     validate(theme: theme, expectedFailures: [], build, file: file, line: line)
   }
-  
+
+  @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
   public func validate<Test: AsyncSequenceValidationTest>(@AsyncSequenceValidationDiagram _ build: (AsyncSequenceValidationDiagram) -> Test, file: StaticString = #file, line: UInt = #line) {
     validate(theme: .ascii, expectedFailures: [], build, file: file, line: line)
   }

--- a/Sources/AsyncSequenceValidation/AsyncSequenceValidationDiagram.swift
+++ b/Sources/AsyncSequenceValidation/AsyncSequenceValidationDiagram.swift
@@ -12,6 +12,7 @@
 import _CAsyncSequenceValidationSupport
 
 @resultBuilder
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 public struct AsyncSequenceValidationDiagram : Sendable {
   public struct Component<T> {
     var component: T
@@ -100,7 +101,6 @@ public struct AsyncSequenceValidationDiagram : Sendable {
   
   public var inputs: InputList
   
-  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
   public var clock: Clock {
     _clock
   }

--- a/Sources/AsyncSequenceValidation/Clock.swift
+++ b/Sources/AsyncSequenceValidation/Clock.swift
@@ -11,6 +11,7 @@
 
 import AsyncAlgorithms
 
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 extension AsyncSequenceValidationDiagram {
   public struct Clock {
     let queue: WorkQueue
@@ -34,6 +35,7 @@ public protocol TestInstant: Equatable {
   associatedtype Duration
 }
 
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 extension AsyncSequenceValidationDiagram.Clock {
   public struct Step: DurationProtocol, Hashable, CustomStringConvertible {
     internal var rawValue: Int
@@ -123,16 +125,22 @@ extension AsyncSequenceValidationDiagram.Clock {
   }
 }
 
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 extension AsyncSequenceValidationDiagram.Clock.Instant: TestInstant { }
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 extension AsyncSequenceValidationDiagram.Clock.Instant: InstantProtocol { }
 
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 extension AsyncSequenceValidationDiagram.Clock: TestClock { }
 
-@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 extension AsyncSequenceValidationDiagram.Clock: Clock { }
 
 // placeholders to avoid warnings
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 extension AsyncSequenceValidationDiagram.Clock.Instant: Hashable { }
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 extension AsyncSequenceValidationDiagram.Clock.Instant: Comparable { }

--- a/Sources/AsyncSequenceValidation/Event.swift
+++ b/Sources/AsyncSequenceValidation/Event.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 extension AsyncSequenceValidationDiagram {
   struct Failure: Error, Equatable { }
   

--- a/Sources/AsyncSequenceValidation/Expectation.swift
+++ b/Sources/AsyncSequenceValidation/Expectation.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 extension AsyncSequenceValidationDiagram {
   public struct ExpectationResult: Sendable {
     public struct Event: Sendable {

--- a/Sources/AsyncSequenceValidation/Input.swift
+++ b/Sources/AsyncSequenceValidation/Input.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 extension AsyncSequenceValidationDiagram {
   public struct Specification: Sendable {
     public let specification: String

--- a/Sources/AsyncSequenceValidation/Job.swift
+++ b/Sources/AsyncSequenceValidation/Job.swift
@@ -11,6 +11,7 @@
 
 import _CAsyncSequenceValidationSupport
 
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 struct Job: Hashable, @unchecked Sendable {
   let job: JobRef
   

--- a/Sources/AsyncSequenceValidation/TaskDriver.swift
+++ b/Sources/AsyncSequenceValidation/TaskDriver.swift
@@ -20,11 +20,13 @@ import _CAsyncSequenceValidationSupport
 #endif
 
 #if canImport(Darwin)
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 func start_thread(_ raw: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer? {
   Unmanaged<TaskDriver>.fromOpaque(raw).takeRetainedValue().run()
   return nil
 }
 #elseif canImport(Glibc)
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 func start_thread(_ raw: UnsafeMutableRawPointer?) -> UnsafeMutableRawPointer? {
   Unmanaged<TaskDriver>.fromOpaque(raw!).takeRetainedValue().run()
   return nil
@@ -33,6 +35,7 @@ func start_thread(_ raw: UnsafeMutableRawPointer?) -> UnsafeMutableRawPointer? {
 #error("TODO: Port TaskDriver threading to windows")
 #endif
 
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 final class TaskDriver {
   let work: (TaskDriver) -> Void
   let queue: WorkQueue

--- a/Sources/AsyncSequenceValidation/Theme.swift
+++ b/Sources/AsyncSequenceValidation/Theme.swift
@@ -9,18 +9,21 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 public protocol AsyncSequenceValidationTheme {
   func token(_ character: Character, inValue: Bool) -> AsyncSequenceValidationDiagram.Token
   
   func description(for token: AsyncSequenceValidationDiagram.Token) -> String
 }
 
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 extension AsyncSequenceValidationTheme where Self == AsyncSequenceValidationDiagram.ASCIITheme {
   public static var ascii: AsyncSequenceValidationDiagram.ASCIITheme {
     return AsyncSequenceValidationDiagram.ASCIITheme()
   }
 }
 
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 extension AsyncSequenceValidationDiagram {
   public enum Token: Sendable {
     case step

--- a/Sources/AsyncSequenceValidation/WorkQueue.swift
+++ b/Sources/AsyncSequenceValidation/WorkQueue.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 struct WorkQueue: Sendable {
   enum Item: CustomStringConvertible, Comparable {
     case blocked(Token, AsyncSequenceValidationDiagram.Clock.Instant, UnsafeContinuation<Void, Error>)

--- a/Tests/AsyncAlgorithmsTests/TestBuffer.swift
+++ b/Tests/AsyncAlgorithmsTests/TestBuffer.swift
@@ -108,6 +108,7 @@ final class TestBuffer: XCTestCase {
     XCTAssertNil(pastFailure)
   }
 
+  @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
   func test_given_a_base_sequence_when_bufferingOldest_then_the_policy_is_applied() async {
     validate {
       "X-12-   34-    5   |"
@@ -116,6 +117,7 @@ final class TestBuffer: XCTestCase {
     }
   }
 
+  @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
   func test_given_a_base_sequence_when_bufferingOldest_with_0_limit_then_the_policy_is_transparent() async {
     validate {
       "X-12-   34-    5   |"
@@ -124,6 +126,7 @@ final class TestBuffer: XCTestCase {
     }
   }
 
+  @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
   func test_given_a_base_sequence_when_bufferingOldest_at_slow_pace_then_no_element_is_dropped() async {
     validate {
       "X-12   3   4   5   |"
@@ -132,6 +135,7 @@ final class TestBuffer: XCTestCase {
     }
   }
 
+  @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
   func test_given_a_failable_base_sequence_when_bufferingOldest_then_the_failure_is_forwarded() async {
     validate {
       "X-12345^"
@@ -140,6 +144,7 @@ final class TestBuffer: XCTestCase {
     }
   }
 
+  @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
   func test_given_a_base_sequence_when_bufferingNewest_then_the_policy_is_applied() async {
     validate {
       "X-12-   34    -5|"
@@ -148,6 +153,7 @@ final class TestBuffer: XCTestCase {
     }
   }
 
+  @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
   func test_given_a_base_sequence_when_bufferingNewest_with_limit_0_then_the_policy_is_transparent() async {
     validate {
       "X-12-   34    -5|"
@@ -156,6 +162,7 @@ final class TestBuffer: XCTestCase {
     }
   }
 
+  @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
   func test_given_a_base_sequence_when_bufferingNewest_at_slow_pace_then_no_element_is_dropped() async {
     validate {
       "X-12   3   4   5   |"
@@ -164,6 +171,7 @@ final class TestBuffer: XCTestCase {
     }
   }
 
+  @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
   func test_given_a_failable_base_sequence_when_bufferingNewest_then_the_failure_is_forwarded() async {
     validate {
       "X-12345^"
@@ -319,6 +327,7 @@ final class TestBuffer: XCTestCase {
     await fulfillment(of: [finished], timeout: 1.0)
   }
 
+  @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
   func test_given_a_base_sequence_when_bounded_with_limit_0_then_the_policy_is_transparent() async {
     validate {
       "X-12-   34    -5|"

--- a/Tests/AsyncAlgorithmsTests/TestChunk.swift
+++ b/Tests/AsyncAlgorithmsTests/TestChunk.swift
@@ -23,6 +23,7 @@ func concatCharacters(_ array: [String]) -> String {
   return array.joined()
 }
 
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 final class TestChunk: XCTestCase {
   func test_signal_equalChunks() {
     validate {
@@ -115,7 +116,6 @@ final class TestChunk: XCTestCase {
   }
 
   func test_time_equalChunks() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "ABC-    DEF-    GHI-     |"
       $0.inputs[0].chunked(by: .repeating(every: .steps(4), clock: $0.clock)).map(concatCharacters)
@@ -124,7 +124,6 @@ final class TestChunk: XCTestCase {
   }
 
   func test_time_unequalChunks() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "AB------    A------- ABCDEFG-         |"
       $0.inputs[0].chunked(by: .repeating(every: .steps(8), clock: $0.clock)).map(concatCharacters)
@@ -133,7 +132,6 @@ final class TestChunk: XCTestCase {
   }
 
   func test_time_emptyChunks() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "-- 1- --|"
       $0.inputs[0].chunked(by: .repeating(every: .steps(2), clock: $0.clock)).map(concatCharacters)
@@ -142,7 +140,6 @@ final class TestChunk: XCTestCase {
   }
 
   func test_time_error() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "AB^"
       $0.inputs[0].chunked(by: .repeating(every: .steps(5), clock: $0.clock)).map(concatCharacters)
@@ -151,7 +148,6 @@ final class TestChunk: XCTestCase {
   }
 
   func test_time_unsignaledTrailingChunk() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "111-111|"
       $0.inputs[0].chunked(by: .repeating(every: .steps(4), clock: $0.clock)).map(sumCharacters)
@@ -160,7 +156,6 @@ final class TestChunk: XCTestCase {
   }
 
   func test_timeAndCount_timeAlwaysPrevails() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "AB------    A------- ABCDEFG-         |"
       $0.inputs[0].chunks(ofCount: 42, or: .repeating(every: .steps(8), clock: $0.clock)).map(concatCharacters)
@@ -169,7 +164,6 @@ final class TestChunk: XCTestCase {
   }
 
   func test_timeAndCount_countAlwaysPrevails() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "AB   --A-B   -|"
       $0.inputs[0].chunks(ofCount: 2, or: .repeating(every: .steps(8), clock: $0.clock)).map(concatCharacters)
@@ -178,7 +172,6 @@ final class TestChunk: XCTestCase {
   }
 
   func test_timeAndCount_countResetsAfterCount() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "ABCDE      --- ABCDE      |"
       $0.inputs[0].chunks(ofCount: 5, or: .repeating(every: .steps(8), clock: $0.clock)).map(concatCharacters)
@@ -187,7 +180,6 @@ final class TestChunk: XCTestCase {
   }
 
   func test_timeAndCount_countResetsAfterSignal() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "AB------    ABCDE      |"
       $0.inputs[0].chunks(ofCount: 5, or: .repeating(every: .steps(8), clock: $0.clock)).map(concatCharacters)
@@ -196,7 +188,6 @@ final class TestChunk: XCTestCase {
   }
 
   func test_timeAndCount_error() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "ABC^"
       $0.inputs[0].chunks(ofCount: 5, or: .repeating(every: .steps(8), clock: $0.clock)).map(concatCharacters)

--- a/Tests/AsyncAlgorithmsTests/TestDebounce.swift
+++ b/Tests/AsyncAlgorithmsTests/TestDebounce.swift
@@ -12,9 +12,9 @@
 import XCTest
 import AsyncAlgorithms
 
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 final class TestDebounce: XCTestCase {
   func test_delayingValues() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "abcd----e---f-g----|"
       $0.inputs[0].debounce(for: .steps(3), clock: $0.clock)
@@ -23,7 +23,6 @@ final class TestDebounce: XCTestCase {
   }
 
   func test_delayingValues_dangling_last() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "abcd----e---f-g-|"
       $0.inputs[0].debounce(for: .steps(3), clock: $0.clock)
@@ -33,7 +32,6 @@ final class TestDebounce: XCTestCase {
 
   
   func test_finishDoesntDebounce() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "a|"
       $0.inputs[0].debounce(for: .steps(3), clock: $0.clock)
@@ -42,7 +40,6 @@ final class TestDebounce: XCTestCase {
   }
   
   func test_throwDoesntDebounce() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "a^"
       $0.inputs[0].debounce(for: .steps(3), clock: $0.clock)
@@ -51,7 +48,6 @@ final class TestDebounce: XCTestCase {
   }
   
   func test_noValues() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "----|"
       $0.inputs[0].debounce(for: .steps(3), clock: $0.clock)
@@ -60,7 +56,6 @@ final class TestDebounce: XCTestCase {
   }
 
     func test_Rethrows() async throws {
-        guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
 
         let debounce = [1].async.debounce(for: .zero, clock: ContinuousClock())
         for await _ in debounce {}
@@ -70,7 +65,6 @@ final class TestDebounce: XCTestCase {
     }
 
   func test_debounce_when_cancelled() async throws {
-      guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
 
       let t = Task {
         try? await Task.sleep(nanoseconds: 1_000_000_000)

--- a/Tests/AsyncAlgorithmsTests/TestMerge.swift
+++ b/Tests/AsyncAlgorithmsTests/TestMerge.swift
@@ -158,7 +158,8 @@ final class TestMerge2: XCTestCase {
     XCTAssertNil(pastEnd)
     XCTAssertEqual(collected.intersection(expected), expected)
   }
-  
+
+  @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
   func test_merge_makes_sequence_with_ordered_elements_when_sources_follow_a_timeline() {
     validate {
       "a-c-e-g-|"
@@ -480,7 +481,8 @@ final class TestMerge3: XCTestCase {
     XCTAssertNil(pastEnd)
     XCTAssertEqual(collected.intersection(expected), expected)
   }
-  
+
+  @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
   func test_merge_makes_sequence_with_ordered_elements_when_sources_follow_a_timeline() {
     validate {
       "a---e---|"

--- a/Tests/AsyncAlgorithmsTests/TestThrottle.swift
+++ b/Tests/AsyncAlgorithmsTests/TestThrottle.swift
@@ -12,9 +12,9 @@
 import XCTest
 import AsyncAlgorithms
 
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 final class TestThrottle: XCTestCase {
   func test_rate_0() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "abcdefghijk|"
       $0.inputs[0].throttle(for: .steps(0), clock: $0.clock)
@@ -23,7 +23,6 @@ final class TestThrottle: XCTestCase {
   }
   
   func test_rate_0_leading_edge() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "abcdefghijk|"
       $0.inputs[0].throttle(for: .steps(0), clock: $0.clock, latest: false)
@@ -32,7 +31,6 @@ final class TestThrottle: XCTestCase {
   }
   
   func test_rate_1() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "abcdefghijk|"
       $0.inputs[0].throttle(for: .steps(1), clock: $0.clock)
@@ -41,7 +39,6 @@ final class TestThrottle: XCTestCase {
   }
   
   func test_rate_1_leading_edge() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "abcdefghijk|"
       $0.inputs[0].throttle(for: .steps(1), clock: $0.clock, latest: false)
@@ -50,7 +47,6 @@ final class TestThrottle: XCTestCase {
   }
   
   func test_rate_2() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "abcdefghijk|"
       $0.inputs[0].throttle(for: .steps(2), clock: $0.clock)
@@ -59,7 +55,6 @@ final class TestThrottle: XCTestCase {
   }
   
   func test_rate_2_leading_edge() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "abcdefghijk|"
       $0.inputs[0].throttle(for: .steps(2), clock: $0.clock, latest: false)
@@ -68,7 +63,6 @@ final class TestThrottle: XCTestCase {
   }
   
   func test_rate_3() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "abcdefghijk|"
       $0.inputs[0].throttle(for: .steps(3), clock: $0.clock)
@@ -77,7 +71,6 @@ final class TestThrottle: XCTestCase {
   }
   
   func test_rate_3_leading_edge() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "abcdefghijk|"
       $0.inputs[0].throttle(for: .steps(3), clock: $0.clock, latest: false)
@@ -86,7 +79,6 @@ final class TestThrottle: XCTestCase {
   }
   
   func test_throwing() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "abcdef^hijk|"
       $0.inputs[0].throttle(for: .steps(2), clock: $0.clock)
@@ -95,7 +87,6 @@ final class TestThrottle: XCTestCase {
   }
   
   func test_throwing_leading_edge() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "abcdef^hijk|"
       $0.inputs[0].throttle(for: .steps(2), clock: $0.clock, latest: false)
@@ -104,7 +95,6 @@ final class TestThrottle: XCTestCase {
   }
   
   func test_emission_2_rate_1() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "-a-b-c-d-e-f-g-h-i-j-k-|"
       $0.inputs[0].throttle(for: .steps(1), clock: $0.clock)
@@ -113,7 +103,6 @@ final class TestThrottle: XCTestCase {
   }
   
   func test_emission_2_rate_2() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "-a-b-c-d-e-f-g-h-i-j-k-|"
       $0.inputs[0].throttle(for: .steps(2), clock: $0.clock)
@@ -122,7 +111,6 @@ final class TestThrottle: XCTestCase {
   }
   
   func test_emission_3_rate_2() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "--a--b--c--d--e--f--g|"
       $0.inputs[0].throttle(for: .steps(2), clock: $0.clock)
@@ -131,7 +119,6 @@ final class TestThrottle: XCTestCase {
   }
   
   func test_emission_2_rate_3() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "-a-b-c-d-e-f-g-h-i-j-k-|"
       $0.inputs[0].throttle(for: .steps(3), clock: $0.clock)

--- a/Tests/AsyncAlgorithmsTests/TestTimer.swift
+++ b/Tests/AsyncAlgorithmsTests/TestTimer.swift
@@ -13,9 +13,9 @@ import XCTest
 import AsyncAlgorithms
 import AsyncSequenceValidation
 
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 final class TestTimer: XCTestCase {
   func test_tick1() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       AsyncTimerSequence(interval: .steps(1), clock: $0.clock).map { _ in "x" }
       "xxxxxxx[;|]"
@@ -23,7 +23,6 @@ final class TestTimer: XCTestCase {
   }
   
   func test_tick2() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       AsyncTimerSequence(interval: .steps(2), clock: $0.clock).map { _ in "x" }
       "-x-x-x-[;|]"
@@ -31,7 +30,6 @@ final class TestTimer: XCTestCase {
   }
   
   func test_tick3() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       AsyncTimerSequence(interval: .steps(3), clock: $0.clock).map { _ in "x" }
       "--x--x-[;|]"
@@ -39,7 +37,6 @@ final class TestTimer: XCTestCase {
   }
   
   func test_tick2_event_skew3() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate { diagram in
       AsyncTimerSequence(interval: .steps(2), clock: diagram.clock).map { [diagram] (_) -> String in
         try? await diagram.clock.sleep(until: diagram.clock.now.advanced(by: .steps(3)))

--- a/Tests/AsyncAlgorithmsTests/TestValidationTests.swift
+++ b/Tests/AsyncAlgorithmsTests/TestValidationTests.swift
@@ -14,6 +14,7 @@ import AsyncAlgorithms
 import AsyncSequenceValidation
 @testable import AsyncAlgorithms_XCTest
 
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
 final class TestValidationDiagram: XCTestCase {
   func test_diagram() {
     validate {
@@ -293,7 +294,6 @@ final class TestValidationDiagram: XCTestCase {
   }
 
   func test_delayNext_into_emptyTick() throws {
-    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "xx|"
       LaggingAsyncSequence($0.inputs[0], delayBy: .steps(3), using: $0.clock)


### PR DESCRIPTION
# Motivation
In one of the recent commits, we have broken the build on Swift 5.7 and 5.8.

# Modification
This PR fixed the compiler errors and makes us build on 5.7 and 5.8 again. I introduced a bunch of availability to the validation setup since the `SerialExecutor` is otherwise not implementable without a warning.

# Result
Works on all of our supported Swift versions again.