### PR TITLE
Remove the validation packages from public products

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,9 +12,6 @@ let package = Package(
   ],
   products: [
     .library(name: "AsyncAlgorithms", targets: ["AsyncAlgorithms"]),
-    .library(name: "AsyncSequenceValidation", targets: ["AsyncSequenceValidation"]),
-    .library(name: "_CAsyncSequenceValidationSupport", type: .static, targets: ["AsyncSequenceValidation"]),
-    .library(name: "AsyncAlgorithms_XCTest", targets: ["AsyncAlgorithms_XCTest"]),
   ],
   dependencies: [.package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.0.4"))],
   targets: [


### PR DESCRIPTION
# Motivation
The current validation testing library has a bunch of warnings and we haven't put it through a proper API review yet. Since we are preparing for a 1.0.0, I think it is best if we remove the products for the validation targets for now and take some time to make sure the interfaces are taken through an API review.

# Modification
Remove products for the validation targets.