### PR TITLE
Rework availability for executor to avoid warnings

### DIFF
--- a/Sources/AsyncSequenceValidation/Job.swift
+++ b/Sources/AsyncSequenceValidation/Job.swift
@@ -19,6 +19,6 @@ struct Job: Hashable, @unchecked Sendable {
   }
   
   func execute() {
-    _swiftJobRun(unsafeBitCast(job, to: UnownedJob.self), AsyncSequenceValidationDiagram.Context.executor.asUnownedSerialExecutor())
+    _swiftJobRun(unsafeBitCast(job, to: UnownedJob.self), AsyncSequenceValidationDiagram.Context.unownedExecutor)
   }
 }


### PR DESCRIPTION
This works-around the warnings for availability for the ExecutorJob while retaining the existing behaviors.