### PR TITLE
make AsyncRemoveDuplicatesSequence's init public

### DIFF
--- a/Sources/AsyncAlgorithms/AsyncRemoveDuplicatesSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncRemoveDuplicatesSequence.swift
@@ -74,7 +74,7 @@ public struct AsyncRemoveDuplicatesSequence<Base: AsyncSequence>: AsyncSequence 
   @usableFromInline
   let predicate: @Sendable (Element, Element) async -> Bool
   
-  init(_ base: Base, predicate: @escaping @Sendable (Element, Element) async -> Bool) {
+  public init(_ base: Base, predicate: @escaping @Sendable (Element, Element) async -> Bool) {
     self.base = base
     self.predicate = predicate
   }


### PR DESCRIPTION
Currently our team is using removeDuplicates() function for the AsyncPublisher in one of our service protocols as a return type. Since for each service we have both live and mock structs, I faced an issue with mocking ASyncRemoveDuplicatesSequence value, as the init is internal.

In this PR I changed it to public. Please, let me know if internal init was intentional approach, so I will try to find another possible way for mocking the return type.