### PR TITLE
Fix `chunks(countOf: 1)`

### DIFF
--- a/Sources/AsyncAlgorithms/AsyncChunksOfCountSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncChunksOfCountSequence.swift
@@ -49,6 +49,10 @@ public struct AsyncChunksOfCountSequence<Base: AsyncSequence, Collected: RangeRe
         return nil
       }
 
+      if count == 1 {
+        return Collected(CollectionOfOne(first))
+      }
+
       var result: Collected = .init()
       result.append(first)
 

--- a/Tests/AsyncAlgorithmsTests/TestChunk.swift
+++ b/Tests/AsyncAlgorithmsTests/TestChunk.swift
@@ -24,6 +24,14 @@ func concatCharacters(_ array: [String]) -> String {
 }
 
 final class TestChunk: XCTestCase {
+  func test_count_one() {
+    validate {
+      "ABCDE|"
+      $0.inputs[0].chunks(ofCount: 1).map(concatCharacters)
+      "ABCDE|"
+    }
+  }
+
   func test_signal_equalChunks() {
     validate {
       "ABC-    DEF-    GHI-     |"


### PR DESCRIPTION
# Motivation
We were failing to properly chunk a sequence if the count was `1` since we only checked for count equality on the second element but never the first one.