### PR TITLE
Remove `@_implementationOnly` usage

### DIFF
--- a/Sources/AsyncAlgorithms/Buffer/BoundedBufferStateMachine.swift
+++ b/Sources/AsyncAlgorithms/Buffer/BoundedBufferStateMachine.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import DequeModule
+import DequeModule
 
 struct BoundedBufferStateMachine<Base: AsyncSequence> {
   typealias Element = Base.Element

--- a/Sources/AsyncAlgorithms/Buffer/UnboundedBufferStateMachine.swift
+++ b/Sources/AsyncAlgorithms/Buffer/UnboundedBufferStateMachine.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import DequeModule
+import DequeModule
 
 struct UnboundedBufferStateMachine<Base: AsyncSequence> {
   typealias Element = Base.Element

--- a/Sources/AsyncAlgorithms/Channels/ChannelStateMachine.swift
+++ b/Sources/AsyncAlgorithms/Channels/ChannelStateMachine.swift
@@ -8,7 +8,7 @@
 // See https://swift.org/LICENSE.txt for license information
 //
 //===----------------------------------------------------------------------===//
-@_implementationOnly import OrderedCollections
+import OrderedCollections
 
 // NOTE: this is only marked as unchecked since the swift-collections tag is before auditing for Sendable
 extension OrderedSet: @unchecked Sendable where Element: Sendable { }

--- a/Sources/AsyncAlgorithms/CombineLatest/CombineLatestStateMachine.swift
+++ b/Sources/AsyncAlgorithms/CombineLatest/CombineLatestStateMachine.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import DequeModule
+import DequeModule
 
 /// State machine for combine latest
 struct CombineLatestStateMachine<

--- a/Sources/AsyncAlgorithms/Locking.swift
+++ b/Sources/AsyncAlgorithms/Locking.swift
@@ -10,11 +10,11 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(Darwin)
-@_implementationOnly import Darwin
+import Darwin
 #elseif canImport(Glibc)
-@_implementationOnly import Glibc
+import Glibc
 #elseif canImport(WinSDK)
-@_implementationOnly import WinSDK
+import WinSDK
 #endif
 
 internal struct Lock {

--- a/Sources/AsyncAlgorithms/Merge/AsyncMerge2Sequence.swift
+++ b/Sources/AsyncAlgorithms/Merge/AsyncMerge2Sequence.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import DequeModule
+import DequeModule
 
 /// Creates an asynchronous sequence of elements from two underlying asynchronous sequences
 public func merge<Base1: AsyncSequence, Base2: AsyncSequence>(_ base1: Base1, _ base2: Base2) -> AsyncMerge2Sequence<Base1, Base2>

--- a/Sources/AsyncAlgorithms/Merge/AsyncMerge3Sequence.swift
+++ b/Sources/AsyncAlgorithms/Merge/AsyncMerge3Sequence.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import DequeModule
+import DequeModule
 
 /// Creates an asynchronous sequence of elements from two underlying asynchronous sequences
 public func merge<

--- a/Sources/AsyncAlgorithms/Merge/MergeStateMachine.swift
+++ b/Sources/AsyncAlgorithms/Merge/MergeStateMachine.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import DequeModule
+import DequeModule
 
 /// The state machine for any of the `merge` operator.
 ///

--- a/Sources/AsyncSequenceValidation/TaskDriver.swift
+++ b/Sources/AsyncSequenceValidation/TaskDriver.swift
@@ -12,9 +12,9 @@
 import _CAsyncSequenceValidationSupport
 
 #if canImport(Darwin)
-@_implementationOnly import Darwin
+import Darwin
 #elseif canImport(Glibc)
-@_implementationOnly import Glibc
+import Glibc
 #elseif canImport(WinSDK)
 #error("TODO: Port TaskDriver threading to windows")
 #endif


### PR DESCRIPTION
# Motivation
We added `@_implementationOnly` a little while ago to hide the dependency on the `DequeModule`. However, with recent compilers this produces a warning since `@_implementationOnly` is only intended to be used in resilient libraries.

# Modification
This PR removes the usage of `@_implementationOnly`