### PR TITLE
Remove majority of `@unchecked Sendable` usages

### DIFF
--- a/Sources/AsyncAlgorithms/Channels/AsyncChannel.swift
+++ b/Sources/AsyncAlgorithms/Channels/AsyncChannel.swift
@@ -19,7 +19,7 @@
 /// on the `Iterator` is made, or when `finish()` is called from another Task.
 /// As `finish()` induces a terminal state, there is no more need for a back pressure management.
 /// This function does not suspend and will finish all the pending iterations.
-public final class AsyncChannel<Element: Sendable>: AsyncSequence, @unchecked Sendable {
+public final class AsyncChannel<Element: Sendable>: AsyncSequence, Sendable {
   public typealias Element = Element
   public typealias AsyncIterator = Iterator
 

--- a/Sources/AsyncAlgorithms/Channels/AsyncThrowingChannel.swift
+++ b/Sources/AsyncAlgorithms/Channels/AsyncThrowingChannel.swift
@@ -18,7 +18,7 @@
 /// and is resumed when the next call to `next()` on the `Iterator` is made, or when `finish()`/`fail(_:)` is called
 /// from another Task. As `finish()` and `fail(_:)` induce a terminal state, there is no more need for a back pressure management.
 /// Those functions do not suspend and will finish all the pending iterations.
-public final class AsyncThrowingChannel<Element: Sendable, Failure: Error>: AsyncSequence, @unchecked Sendable {
+public final class AsyncThrowingChannel<Element: Sendable, Failure: Error>: AsyncSequence, Sendable {
   public typealias Element = Element
   public typealias AsyncIterator = Iterator
 

--- a/Sources/AsyncAlgorithms/Debounce/AsyncDebounceSequence.swift
+++ b/Sources/AsyncAlgorithms/Debounce/AsyncDebounceSequence.swift
@@ -13,14 +13,14 @@ extension AsyncSequence {
     /// Creates an asynchronous sequence that emits the latest element after a given quiescence period
     /// has elapsed by using a specified Clock.
     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-    public func debounce<C: Clock>(for interval: C.Instant.Duration, tolerance: C.Instant.Duration? = nil, clock: C) -> AsyncDebounceSequence<Self, C> where Self: Sendable {
+    public func debounce<C: Clock>(for interval: C.Instant.Duration, tolerance: C.Instant.Duration? = nil, clock: C) -> AsyncDebounceSequence<Self, C> where Self: Sendable, Self.Element: Sendable {
         AsyncDebounceSequence(self, interval: interval, tolerance: tolerance, clock: clock)
     }
 
     /// Creates an asynchronous sequence that emits the latest element after a given quiescence period
     /// has elapsed.
     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-    public func debounce(for interval: Duration, tolerance: Duration? = nil) -> AsyncDebounceSequence<Self, ContinuousClock> where Self: Sendable {
+    public func debounce(for interval: Duration, tolerance: Duration? = nil) -> AsyncDebounceSequence<Self, ContinuousClock> where Self: Sendable, Self.Element: Sendable {
         self.debounce(for: interval, tolerance: tolerance, clock: .continuous)
     }
 }
@@ -28,7 +28,7 @@ extension AsyncSequence {
 /// An `AsyncSequence` that emits the latest element after a given quiescence period
 /// has elapsed.
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-public struct AsyncDebounceSequence<Base: AsyncSequence, C: Clock>: Sendable where Base: Sendable {
+public struct AsyncDebounceSequence<Base: AsyncSequence & Sendable, C: Clock>: Sendable where Base.Element: Sendable {
     private let base: Base
     private let clock: C
     private let interval: C.Instant.Duration

--- a/Sources/AsyncAlgorithms/Debounce/DebounceStateMachine.swift
+++ b/Sources/AsyncAlgorithms/Debounce/DebounceStateMachine.swift
@@ -10,10 +10,10 @@
 //===----------------------------------------------------------------------===//
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-struct DebounceStateMachine<Base: AsyncSequence, C: Clock> {
+struct DebounceStateMachine<Base: AsyncSequence & Sendable, C: Clock>: Sendable where Base.Element: Sendable {
     typealias Element = Base.Element
 
-    private enum State {
+    private enum State: Sendable {
         /// The initial state before a call to `next` happened.
         case initial(base: Base)
 

--- a/Sources/AsyncAlgorithms/Debounce/DebounceStorage.swift
+++ b/Sources/AsyncAlgorithms/Debounce/DebounceStorage.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-final class DebounceStorage<Base: AsyncSequence, C: Clock>: @unchecked Sendable where Base: Sendable {
+final class DebounceStorage<Base: AsyncSequence & Sendable, C: Clock>: Sendable where Base.Element: Sendable {
     typealias Element = Base.Element
 
     /// The state machine protected with a lock.


### PR DESCRIPTION
# Motivation
`@unchecked Sendable` is a great way to make a type `Sendable` while it is not really `Sendable` this is rarely useful and we should rather use conditional `@unchecked Sendable` annotations such as the one on `ManagedCriticalState`

# Modification
This PR removes all `@unchecked Sendable` in the main algorithm target except the one on `Merge` since we are doing manual locking there.

# Result
No more `@unchecked Sendable` usage.