### PR TITLE
Fix 5.7/5.8 build errors

### DIFF
--- a/Sources/AsyncAlgorithms/AsyncThrottleSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncThrottleSequence.swift
@@ -85,7 +85,7 @@ extension AsyncThrottleSequence: AsyncSequence {
             // ensure the rate of elements never exceeds the given interval
             let amount = interval - last.duration(to: clock.now)
             if amount > .zero {
-              try? await clock.sleep(for: amount)
+              try? await clock.sleep(until: clock.now.advanced(by: amount), tolerance: nil)
             }
           }
           // the last value is unable to have any subsequent


### PR DESCRIPTION
# Motivation

Currently, this repo fails to build on Swift 5.7 and 5.8 since we were using clock APIs that were only available on 5.9.