### PR TITLE
Fix potential deadlocks when resuming a continuation while holding a lock

### DIFF
--- a/Sources/AsyncAlgorithms/Buffer/BoundedBufferStorage.swift
+++ b/Sources/AsyncAlgorithms/Buffer/BoundedBufferStorage.swift
@@ -18,34 +18,47 @@ final class BoundedBufferStorage<Base: AsyncSequence>: Sendable where Base: Send
 
   func next() async -> Result<Base.Element, Error>? {
     return await withTaskCancellationHandler {
-      let (shouldSuspend, result) = self.stateMachine.withCriticalRegion { stateMachine -> (Bool, Result<Base.Element, Error>?) in
+      let action: BoundedBufferStateMachine<Base>.NextAction? = self.stateMachine.withCriticalRegion { stateMachine in
         let action = stateMachine.next()
         switch action {
           case .startTask(let base):
             self.startTask(stateMachine: &stateMachine, base: base)
-            return (true, nil)
+            return nil
+
           case .suspend:
-            return (true, nil)
-          case .returnResult(let producerContinuation, let result):
-            producerContinuation?.resume()
-            return (false, result)
+            return action
+          case .returnResult:
+            return action
         }
       }
 
-      if !shouldSuspend {
-        return result
+      switch action {
+        case .startTask:
+          // We are handling the startTask in the lock already because we want to avoid
+          // other inputs interleaving while starting the task
+          fatalError("Internal inconsistency")
+
+        case .suspend:
+          break
+
+        case .returnResult(let producerContinuation, let result):
+          producerContinuation?.resume()
+          return result
+
+      case .none:
+        break
       }
 
       return await withUnsafeContinuation { (continuation: UnsafeContinuation<Result<Base.Element, Error>?, Never>) in
-        self.stateMachine.withCriticalRegion { stateMachine in
-          let action = stateMachine.nextSuspended(continuation: continuation)
-          switch action {
-            case .none:
-              break
-            case .returnResult(let producerContinuation, let result):
-              producerContinuation?.resume()
-              continuation.resume(returning: result)
-          }
+        let action = self.stateMachine.withCriticalRegion { stateMachine in
+          stateMachine.nextSuspended(continuation: continuation)
+        }
+        switch action {
+          case .none:
+            break
+          case .returnResult(let producerContinuation, let result):
+            producerContinuation?.resume()
+            continuation.resume(returning: result)
         }
       }
     } onCancel: {
@@ -68,15 +81,15 @@ final class BoundedBufferStorage<Base: AsyncSequence>: Sendable where Base: Send
 
           if shouldSuspend {
             await withUnsafeContinuation { (continuation: UnsafeContinuation<Void, Never>) in
-              self.stateMachine.withCriticalRegion { stateMachine in
-                let action = stateMachine.producerSuspended(continuation: continuation)
+              let action = self.stateMachine.withCriticalRegion { stateMachine in
+                stateMachine.producerSuspended(continuation: continuation)
+              }
 
-                switch action {
-                  case .none:
-                    break
-                  case .resumeProducer:
-                    continuation.resume()
-                }
+              switch action {
+                case .none:
+                  break
+                case .resumeProducer:
+                  continuation.resume()
               }
             }
           }
@@ -86,35 +99,35 @@ final class BoundedBufferStorage<Base: AsyncSequence>: Sendable where Base: Send
             break loop
           }
 
-          self.stateMachine.withCriticalRegion { stateMachine in
-            let action = stateMachine.elementProduced(element: element)
-            switch action {
-              case .none:
-                break
-              case .resumeConsumer(let continuation, let result):
-                continuation.resume(returning: result)
-            }
+          let action = self.stateMachine.withCriticalRegion { stateMachine in
+            stateMachine.elementProduced(element: element)
+          }
+          switch action {
+            case .none:
+              break
+            case .resumeConsumer(let continuation, let result):
+              continuation.resume(returning: result)
           }
         }
 
-        self.stateMachine.withCriticalRegion { stateMachine in
-          let action = stateMachine.finish(error: nil)
-          switch action {
-            case .none:
-              break
-            case .resumeConsumer(let continuation):
-              continuation?.resume(returning: nil)
-          }
+        let action = self.stateMachine.withCriticalRegion { stateMachine in
+          stateMachine.finish(error: nil)
+        }
+        switch action {
+          case .none:
+            break
+          case .resumeConsumer(let continuation):
+            continuation?.resume(returning: nil)
         }
       } catch {
-        self.stateMachine.withCriticalRegion { stateMachine in
-          let action = stateMachine.finish(error: error)
-          switch action {
-            case .none:
-              break
-            case .resumeConsumer(let continuation):
-              continuation?.resume(returning: .failure(error))
-          }
+        let action = self.stateMachine.withCriticalRegion { stateMachine in
+          stateMachine.finish(error: error)
+        }
+        switch action {
+          case .none:
+            break
+          case .resumeConsumer(let continuation):
+            continuation?.resume(returning: .failure(error))
         }
       }
     }
@@ -123,16 +136,16 @@ final class BoundedBufferStorage<Base: AsyncSequence>: Sendable where Base: Send
   }
 
   func interrupted() {
-    self.stateMachine.withCriticalRegion { stateMachine in
-      let action = stateMachine.interrupted()
-      switch action {
-        case .none:
-          break
-        case .resumeProducerAndConsumer(let task, let producerContinuation, let consumerContinuation):
-          task.cancel()
-          producerContinuation?.resume()
-          consumerContinuation?.resume(returning: nil)
-      }
+    let action = self.stateMachine.withCriticalRegion { stateMachine in
+      stateMachine.interrupted()
+    }
+    switch action {
+      case .none:
+        break
+      case .resumeProducerAndConsumer(let task, let producerContinuation, let consumerContinuation):
+        task.cancel()
+        producerContinuation?.resume()
+        consumerContinuation?.resume(returning: nil)
     }
   }
 

--- a/Sources/AsyncAlgorithms/Debounce/DebounceStorage.swift
+++ b/Sources/AsyncAlgorithms/Debounce/DebounceStorage.swift
@@ -55,36 +55,59 @@ final class DebounceStorage<Base: AsyncSequence & Sendable, C: Clock>: Sendable 
             // We always suspend since we can never return an element right away
 
             let result: Result<Element?, Error> = await withUnsafeContinuation { continuation in
-                self.stateMachine.withCriticalRegion {
-                    let action = $0.next(for: continuation)
+              let action: DebounceStateMachine<Base, C>.NextAction? = self.stateMachine.withCriticalRegion {
+                let action = $0.next(for: continuation)
 
-                    switch action {
-                    case .startTask(let base):
-                        self.startTask(
-                            stateMachine: &$0,
-                            base: base,
-                            downstreamContinuation: continuation
-                        )
+                switch action {
+                case .startTask(let base):
+                  self.startTask(
+                      stateMachine: &$0,
+                      base: base,
+                      downstreamContinuation: continuation
+                  )
+                  return nil
 
-                    case .resumeUpstreamContinuation(let upstreamContinuation):
-                        // This is signalling the upstream task that is consuming the upstream
-                        // sequence to signal demand.
-                        upstreamContinuation?.resume(returning: ())
+                case .resumeUpstreamContinuation:
+                  return action
 
-                    case .resumeUpstreamAndClockContinuation(let upstreamContinuation, let clockContinuation, let deadline):
-                        // This is signalling the upstream task that is consuming the upstream
-                        // sequence to signal demand and start the clock task.
-                        upstreamContinuation?.resume(returning: ())
-                        clockContinuation?.resume(returning: deadline)
+                case .resumeUpstreamAndClockContinuation:
+                  return action
 
-                    case .resumeDownstreamContinuationWithNil(let continuation):
-                        continuation.resume(returning: .success(nil))
+                case .resumeDownstreamContinuationWithNil:
+                  return action
 
-                    case .resumeDownstreamContinuationWithError(let continuation, let error):
-                        continuation.resume(returning: .failure(error))
-                    }
+                case .resumeDownstreamContinuationWithError:
+                  return action
                 }
-            }
+              }
+
+              switch action {
+              case .startTask:
+                // We are handling the startTask in the lock already because we want to avoid
+                // other inputs interleaving while starting the task
+                fatalError("Internal inconsistency")
+
+              case .resumeUpstreamContinuation(let upstreamContinuation):
+                // This is signalling the upstream task that is consuming the upstream
+                // sequence to signal demand.
+                upstreamContinuation?.resume(returning: ())
+
+              case .resumeUpstreamAndClockContinuation(let upstreamContinuation, let clockContinuation, let deadline):
+                // This is signalling the upstream task that is consuming the upstream
+                // sequence to signal demand and start the clock task.
+                upstreamContinuation?.resume(returning: ())
+                clockContinuation?.resume(returning: deadline)
+
+              case .resumeDownstreamContinuationWithNil(let continuation):
+                continuation.resume(returning: .success(nil))
+
+              case .resumeDownstreamContinuationWithError(let continuation, let error):
+                continuation.resume(returning: .failure(error))
+
+              case .none:
+                break
+              }
+          }
 
             return try result._rethrowGet()
         } onCancel: {
@@ -258,37 +281,38 @@ final class DebounceStorage<Base: AsyncSequence & Sendable, C: Clock>: Sendable 
                     do {
                         try await group.next()
                     } catch {
-                    // One of the upstream sequences threw an error
-                        self.stateMachine.withCriticalRegion { stateMachine in
-                            let action = stateMachine.upstreamThrew(error)
-                            switch action {
-                            case .resumeContinuationWithErrorAndCancelTaskAndUpstreamContinuation(
-                                let downstreamContinuation,
-                                let error,
-                                let task,
-                                let upstreamContinuation,
-                                let clockContinuation
-                            ):
-                                upstreamContinuation?.resume(throwing: CancellationError())
-                                clockContinuation?.resume(throwing: CancellationError())
-
-                                task.cancel()
-
-                                downstreamContinuation.resume(returning: .failure(error))
-
-                            case .cancelTaskAndClockContinuation(
-                                let task,
-                                let clockContinuation
-                            ):
-                                clockContinuation?.resume(throwing: CancellationError())
-                                task.cancel()
-                            case .none:
-                                break
-                            }
+                        // One of the upstream sequences threw an error
+                        let action = self.stateMachine.withCriticalRegion { stateMachine in
+                          stateMachine.upstreamThrew(error)
                         }
 
-                        group.cancelAll()
+                        switch action {
+                        case .resumeContinuationWithErrorAndCancelTaskAndUpstreamContinuation(
+                            let downstreamContinuation,
+                            let error,
+                            let task,
+                            let upstreamContinuation,
+                            let clockContinuation
+                        ):
+                            upstreamContinuation?.resume(throwing: CancellationError())
+                            clockContinuation?.resume(throwing: CancellationError())
+
+                            task.cancel()
+
+                            downstreamContinuation.resume(returning: .failure(error))
+
+                        case .cancelTaskAndClockContinuation(
+                            let task,
+                            let clockContinuation
+                        ):
+                            clockContinuation?.resume(throwing: CancellationError())
+                            task.cancel()
+                        case .none:
+                            break
+                        }
                     }
+
+                    group.cancelAll()
                 }
             }
         }

--- a/Sources/AsyncAlgorithms/Zip/ZipStorage.swift
+++ b/Sources/AsyncAlgorithms/Zip/ZipStorage.swift
@@ -39,7 +39,7 @@ final class ZipStorage<Base1: AsyncSequence, Base2: AsyncSequence, Base3: AsyncS
   func next() async rethrows -> (Base1.Element, Base2.Element, Base3.Element?)? {
     try await withTaskCancellationHandler {
       let result = await withUnsafeContinuation { continuation in
-        self.stateMachine.withCriticalRegion { stateMachine in
+        let action: StateMachine.NextAction? = self.stateMachine.withCriticalRegion { stateMachine in
           let action = stateMachine.next(for: continuation)
           switch action {
           case .startTask(let base1, let base2, let base3):
@@ -51,42 +51,59 @@ final class ZipStorage<Base1: AsyncSequence, Base2: AsyncSequence, Base3: AsyncS
               base3: base3,
               downstreamContinuation: continuation
             )
+            return nil
 
-          case .resumeUpstreamContinuations(let upstreamContinuations):
-            // bases can be iterated over for 1 iteration so their next value can be retrieved
-            upstreamContinuations.forEach { $0.resume() }
+          case .resumeUpstreamContinuations:
+            return action
 
-          case .resumeDownstreamContinuationWithNil(let continuation):
-            // the async sequence is already finished, immediately resuming
-            continuation.resume(returning: .success(nil))
+          case .resumeDownstreamContinuationWithNil:
+            return action
           }
+        }
+
+        switch action {
+        case .startTask:
+            // We are handling the startTask in the lock already because we want to avoid
+            // other inputs interleaving while starting the task
+            fatalError("Internal inconsistency")
+
+        case .resumeUpstreamContinuations(let upstreamContinuations):
+          // bases can be iterated over for 1 iteration so their next value can be retrieved
+          upstreamContinuations.forEach { $0.resume() }
+
+        case .resumeDownstreamContinuationWithNil(let continuation):
+          // the async sequence is already finished, immediately resuming
+          continuation.resume(returning: .success(nil))
+
+        case .none:
+            break
         }
       }
 
       return try result._rethrowGet()
 
     } onCancel: {
-      self.stateMachine.withCriticalRegion { stateMachine in
-        let action = stateMachine.cancelled()
+      let action = self.stateMachine.withCriticalRegion { stateMachine in
+        stateMachine.cancelled()
+      }
 
-        switch action {
-        case .resumeDownstreamContinuationWithNilAndCancelTaskAndUpstreamContinuations(
-          let downstreamContinuation,
-          let task,
-          let upstreamContinuations
-        ):
-          upstreamContinuations.forEach { $0.resume(throwing: CancellationError()) }
-          task.cancel()
+      switch action {
+      case .resumeDownstreamContinuationWithNilAndCancelTaskAndUpstreamContinuations(
+        let downstreamContinuation,
+        let task,
+        let upstreamContinuations
+      ):
+        upstreamContinuations.forEach { $0.resume(throwing: CancellationError()) }
+        task.cancel()
 
-          downstreamContinuation.resume(returning: .success(nil))
+        downstreamContinuation.resume(returning: .success(nil))
 
-        case .cancelTaskAndUpstreamContinuations(let task, let upstreamContinuations):
-          upstreamContinuations.forEach { $0.resume(throwing: CancellationError()) }
-          task.cancel()
+      case .cancelTaskAndUpstreamContinuations(let task, let upstreamContinuations):
+        upstreamContinuations.forEach { $0.resume(throwing: CancellationError()) }
+        task.cancel()
 
-        case .none:
-          break
-        }
+      case .none:
+        break
       }
     }
   }
@@ -112,53 +129,53 @@ final class ZipStorage<Base1: AsyncSequence, Base2: AsyncSequence, Base3: AsyncS
             // element from upstream. This continuation is only resumed
             // if the downstream consumer called `next` to signal his demand.
             try await withUnsafeThrowingContinuation { continuation in
-              self.stateMachine.withCriticalRegion { stateMachine in
-                let action = stateMachine.childTaskSuspended(baseIndex: 0, continuation: continuation)
+              let action = self.stateMachine.withCriticalRegion { stateMachine in
+                stateMachine.childTaskSuspended(baseIndex: 0, continuation: continuation)
+              }
 
-                switch action {
-                case .resumeContinuation(let upstreamContinuation):
-                  upstreamContinuation.resume()
+              switch action {
+              case .resumeContinuation(let upstreamContinuation):
+                upstreamContinuation.resume()
 
-                case .resumeContinuationWithError(let upstreamContinuation, let error):
-                  upstreamContinuation.resume(throwing: error)
+              case .resumeContinuationWithError(let upstreamContinuation, let error):
+                upstreamContinuation.resume(throwing: error)
 
-                case .none:
-                  break
-                }
+              case .none:
+                break
               }
             }
 
             if let element1 = try await base1Iterator.next() {
-              self.stateMachine.withCriticalRegion { stateMachine in
-                let action = stateMachine.elementProduced((element1, nil, nil))
+              let action = self.stateMachine.withCriticalRegion { stateMachine in
+                stateMachine.elementProduced((element1, nil, nil))
+              }
 
-                switch action {
-                case .resumeContinuation(let downstreamContinuation, let result):
-                  downstreamContinuation.resume(returning: result)
+              switch action {
+              case .resumeContinuation(let downstreamContinuation, let result):
+                downstreamContinuation.resume(returning: result)
 
-                case .none:
-                  break
-                }
+              case .none:
+                break
               }
             } else {
-              self.stateMachine.withCriticalRegion { stateMachine in
-                let action = stateMachine.upstreamFinished()
+              let action = self.stateMachine.withCriticalRegion { stateMachine in
+                stateMachine.upstreamFinished()
+              }
 
-                switch action {
-                case .resumeContinuationWithNilAndCancelTaskAndUpstreamContinuations(
-                  let downstreamContinuation,
-                  let task,
-                  let upstreamContinuations
-                ):
+              switch action {
+              case .resumeContinuationWithNilAndCancelTaskAndUpstreamContinuations(
+                let downstreamContinuation,
+                let task,
+                let upstreamContinuations
+              ):
 
-                  upstreamContinuations.forEach { $0.resume(throwing: CancellationError()) }
-                  task.cancel()
+                upstreamContinuations.forEach { $0.resume(throwing: CancellationError()) }
+                task.cancel()
 
-                  downstreamContinuation.resume(returning: .success(nil))
+                downstreamContinuation.resume(returning: .success(nil))
 
-                case .none:
-                  break
-                }
+              case .none:
+                break
               }
             }
           }
@@ -172,53 +189,53 @@ final class ZipStorage<Base1: AsyncSequence, Base2: AsyncSequence, Base3: AsyncS
             // element from upstream. This continuation is only resumed
             // if the downstream consumer called `next` to signal his demand.
             try await withUnsafeThrowingContinuation { continuation in
-              self.stateMachine.withCriticalRegion { stateMachine in
-                let action = stateMachine.childTaskSuspended(baseIndex: 1, continuation: continuation)
+              let action = self.stateMachine.withCriticalRegion { stateMachine in
+                stateMachine.childTaskSuspended(baseIndex: 1, continuation: continuation)
+              }
 
-                switch action {
-                case .resumeContinuation(let upstreamContinuation):
-                  upstreamContinuation.resume()
+              switch action {
+              case .resumeContinuation(let upstreamContinuation):
+                upstreamContinuation.resume()
 
-                case .resumeContinuationWithError(let upstreamContinuation, let error):
-                  upstreamContinuation.resume(throwing: error)
+              case .resumeContinuationWithError(let upstreamContinuation, let error):
+                upstreamContinuation.resume(throwing: error)
 
-                case .none:
-                  break
-                }
+              case .none:
+                break
               }
             }
 
             if let element2 = try await base2Iterator.next() {
-              self.stateMachine.withCriticalRegion { stateMachine in
-                let action = stateMachine.elementProduced((nil, element2, nil))
+              let action = self.stateMachine.withCriticalRegion { stateMachine in
+                stateMachine.elementProduced((nil, element2, nil))
+              }
 
-                switch action {
-                case .resumeContinuation(let downstreamContinuation, let result):
-                  downstreamContinuation.resume(returning: result)
+              switch action {
+              case .resumeContinuation(let downstreamContinuation, let result):
+                downstreamContinuation.resume(returning: result)
 
-                case .none:
-                  break
-                }
+              case .none:
+                break
               }
             } else {
-              self.stateMachine.withCriticalRegion { stateMachine in
-                let action = stateMachine.upstreamFinished()
+              let action = self.stateMachine.withCriticalRegion { stateMachine in
+                stateMachine.upstreamFinished()
+              }
 
-                switch action {
-                case .resumeContinuationWithNilAndCancelTaskAndUpstreamContinuations(
-                  let downstreamContinuation,
-                  let task,
-                  let upstreamContinuations
-                ):
+              switch action {
+              case .resumeContinuationWithNilAndCancelTaskAndUpstreamContinuations(
+                let downstreamContinuation,
+                let task,
+                let upstreamContinuations
+              ):
 
-                  upstreamContinuations.forEach { $0.resume(throwing: CancellationError()) }
-                  task.cancel()
+                upstreamContinuations.forEach { $0.resume(throwing: CancellationError()) }
+                task.cancel()
 
-                  downstreamContinuation.resume(returning: .success(nil))
+                downstreamContinuation.resume(returning: .success(nil))
 
-                case .none:
-                  break
-                }
+              case .none:
+                break
               }
             }
           }
@@ -233,53 +250,53 @@ final class ZipStorage<Base1: AsyncSequence, Base2: AsyncSequence, Base3: AsyncS
               // element from upstream. This continuation is only resumed
               // if the downstream consumer called `next` to signal his demand.
               try await withUnsafeThrowingContinuation { continuation in
-                self.stateMachine.withCriticalRegion { stateMachine in
-                  let action = stateMachine.childTaskSuspended(baseIndex: 2, continuation: continuation)
+                let action = self.stateMachine.withCriticalRegion { stateMachine in
+                  stateMachine.childTaskSuspended(baseIndex: 2, continuation: continuation)
+                }
 
-                  switch action {
-                  case .resumeContinuation(let upstreamContinuation):
-                    upstreamContinuation.resume()
+                switch action {
+                case .resumeContinuation(let upstreamContinuation):
+                  upstreamContinuation.resume()
 
-                  case .resumeContinuationWithError(let upstreamContinuation, let error):
-                    upstreamContinuation.resume(throwing: error)
+                case .resumeContinuationWithError(let upstreamContinuation, let error):
+                  upstreamContinuation.resume(throwing: error)
 
-                  case .none:
-                    break
-                  }
+                case .none:
+                  break
                 }
               }
 
               if let element3 = try await base3Iterator.next() {
-                self.stateMachine.withCriticalRegion { stateMachine in
-                  let action = stateMachine.elementProduced((nil, nil, element3))
+                let action = self.stateMachine.withCriticalRegion { stateMachine in
+                  stateMachine.elementProduced((nil, nil, element3))
+                }
 
-                  switch action {
-                  case .resumeContinuation(let downstreamContinuation, let result):
-                    downstreamContinuation.resume(returning: result)
+                switch action {
+                case .resumeContinuation(let downstreamContinuation, let result):
+                  downstreamContinuation.resume(returning: result)
 
-                  case .none:
-                    break
-                  }
+                case .none:
+                  break
                 }
               } else {
-                self.stateMachine.withCriticalRegion { stateMachine in
-                  let action = stateMachine.upstreamFinished()
+                let action = self.stateMachine.withCriticalRegion { stateMachine in
+                  stateMachine.upstreamFinished()
+                }
 
-                  switch action {
-                  case .resumeContinuationWithNilAndCancelTaskAndUpstreamContinuations(
-                    let downstreamContinuation,
-                    let task,
-                    let upstreamContinuations
-                  ):
+                switch action {
+                case .resumeContinuationWithNilAndCancelTaskAndUpstreamContinuations(
+                  let downstreamContinuation,
+                  let task,
+                  let upstreamContinuations
+                ):
 
-                    upstreamContinuations.forEach { $0.resume(throwing: CancellationError()) }
-                    task.cancel()
+                  upstreamContinuations.forEach { $0.resume(throwing: CancellationError()) }
+                  task.cancel()
 
-                    downstreamContinuation.resume(returning: .success(nil))
+                  downstreamContinuation.resume(returning: .success(nil))
 
-                  case .none:
-                    break
-                  }
+                case .none:
+                  break
                 }
               }
             }
@@ -291,25 +308,25 @@ final class ZipStorage<Base1: AsyncSequence, Base2: AsyncSequence, Base3: AsyncS
                 try await group.next()
             } catch {
             // One of the upstream sequences threw an error
-                self.stateMachine.withCriticalRegion { stateMachine in
-                    let action = stateMachine.upstreamThrew(error)
-                    switch action {
-                    case .resumeContinuationWithErrorAndCancelTaskAndUpstreamContinuations(
-                      let downstreamContinuation,
-                      let error,
-                      let task,
-                      let upstreamContinuations
-                    ):
-                      upstreamContinuations.forEach { $0.resume(throwing: CancellationError()) }
-                      task.cancel()
+              let action = self.stateMachine.withCriticalRegion { stateMachine in
+                stateMachine.upstreamThrew(error)
+              }
+              switch action {
+              case .resumeContinuationWithErrorAndCancelTaskAndUpstreamContinuations(
+                let downstreamContinuation,
+                let error,
+                let task,
+                let upstreamContinuations
+              ):
+                upstreamContinuations.forEach { $0.resume(throwing: CancellationError()) }
+                task.cancel()
 
-                      downstreamContinuation.resume(returning: .failure(error))
-                    case .none:
-                        break
-                    }
-                }
+                downstreamContinuation.resume(returning: .failure(error))
+              case .none:
+                  break
+              }
 
-                group.cancelAll()
+              group.cancelAll()
             }
         }
       }


### PR DESCRIPTION
We wrongly assumed that it is safe to resume continuations while holding our state machine lock. There is a potential for a deadlock in rare circumstances. The problem is that the runtime holds a task specific lock. This lock is both acquired by task cancellation and continuation resumption. This can lead to scenarios where we are resuming the task's continuation while holding the state machine lock and a different thread cancelling the task and holding the runtime lock. Now both locks are held by different threads and they are waiting to acquire the opposite lock; hence, deadlocking the process.

In this PR, I went through all of our state machine based implementations and made sure that we are only acquiring the lock for as little as possible and handle all of the actions outside of the lock.