### PR TITLE
Depend on specific products from swift-collections

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
   targets: [
     .target(
       name: "AsyncAlgorithms",
-      dependencies: [.product(name: "Collections", package: "swift-collections")],
+      dependencies: [.product(name: "OrderedCollections", package: "swift-collections")],
       swiftSettings: [
           .enableExperimentalFeature("StrictConcurrency=complete"),
       ]

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,10 @@ let package = Package(
   targets: [
     .target(
       name: "AsyncAlgorithms",
-      dependencies: [.product(name: "OrderedCollections", package: "swift-collections")],
+      dependencies: [
+          .product(name: "OrderedCollections", package: "swift-collections"),
+          .product(name: "DequeModule", package: "swift-collections"),
+      ],
       swiftSettings: [
           .enableExperimentalFeature("StrictConcurrency=complete"),
       ]


### PR DESCRIPTION
Before this change, once consumers update to SwiftCollections 1.1.0 they'll pull in all of the new collection dependencies (HashTree, BitCollections, etc.). In our case, this increased our binary size by ~1MB. To fix this, we switch to only depending on what we need.