### PR TITLE
Add support for `SWIFTCI_USE_LOCAL_DEPS` convention

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,10 +13,6 @@ let package = Package(
   products: [
     .library(name: "AsyncAlgorithms", targets: ["AsyncAlgorithms"]),
   ],
-  dependencies: [
-    .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
-    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-  ],
   targets: [
     .target(
       name: "AsyncAlgorithms",
@@ -52,3 +48,14 @@ let package = Package(
     ),
   ]
 )
+
+if Context.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
+  package.dependencies += [
+    .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
+    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+  ]
+} else {
+  package.dependencies += [
+    .package(path: "../swift-collections"),
+  ]
+}


### PR DESCRIPTION
This package is used by https://github.com/apple/swift-sdk-generator and it needs to be built during build-script pipeline, so we need to make its dependencies follow the CI convention. CC: @MaxDesiatov 