### PR TITLE
async chunked sequences can produce empty chunks

### DIFF
--- a/Sources/AsyncAlgorithms/Deprecated.swift
+++ b/Sources/AsyncAlgorithms/Deprecated.swift
@@ -1,0 +1,63 @@
+
+
+extension AsyncSequence {
+  /// Creates an asynchronous sequence that creates chunks of a given `RangeReplaceableCollection` type of a given count or when a signal `AsyncSequence` produces an element.
+  @_disfavoredOverload
+  @available(*, deprecated, renamed: "chunks(ofCount:or:into:produceEmptyChunks:)", message: "This method has been deprecated to allow the option for sequences to produce empty chunks.")
+  public func chunks<Signal, Collected: RangeReplaceableCollection>(ofCount count: Int, or signal: Signal, into: Collected.Type) -> AsyncChunksOfCountOrSignalSequence<Self, Collected, Signal> where Collected.Element == Element {
+    AsyncChunksOfCountOrSignalSequence(self, count: count, signal: signal, produceEmptyChunks: false)
+  }
+
+  /// Creates an asynchronous sequence that creates chunks of a given count or when a signal `AsyncSequence` produces an element.
+  @_disfavoredOverload
+  @available(*, deprecated, renamed: "chunks(ofCount:or:produceEmptyChunks:)", message: "This method has been deprecated to allow the option for sequences to produce empty chunks.")
+  public func chunks<Signal>(ofCount count: Int, or signal: Signal) -> AsyncChunksOfCountOrSignalSequence<Self, [Element], Signal> {
+    chunks(ofCount: count, or: signal, into: [Element].self)
+  }
+
+  /// Creates an asynchronous sequence that creates chunks of a given `RangeReplaceableCollection` type when a signal `AsyncSequence` produces an element.
+  @_disfavoredOverload
+  @available(*, deprecated, renamed: "chunked(by:into:produceEmptyChunks:)", message: "This method has been deprecated to allow the option for sequences to produce empty chunks.")
+  public func chunked<Signal, Collected: RangeReplaceableCollection>(by signal: Signal, into: Collected.Type) -> AsyncChunksOfCountOrSignalSequence<Self, Collected, Signal> where Collected.Element == Element {
+    AsyncChunksOfCountOrSignalSequence(self, count: nil, signal: signal, produceEmptyChunks: false)
+  }
+
+  /// Creates an asynchronous sequence that creates chunks when a signal `AsyncSequence` produces an element.
+  @_disfavoredOverload
+  @available(*, deprecated, renamed: "chunked(by:produceEmptyChunks:)", message: "This method has been deprecated to allow the option for sequences to produce empty chunks.")
+  public func chunked<Signal>(by signal: Signal) -> AsyncChunksOfCountOrSignalSequence<Self, [Element], Signal> {
+    chunked(by: signal, into: [Element].self)
+  }
+
+  /// Creates an asynchronous sequence that creates chunks of a given `RangeReplaceableCollection` type of a given count or when an `AsyncTimerSequence` fires.
+  @_disfavoredOverload
+  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+  @available(*, deprecated, renamed: "chunks(ofCount:or:into:produceEmptyChunks:)", message: "This method has been deprecated to allow the option for sequences to produce empty chunks.")
+  public func chunks<C: Clock, Collected: RangeReplaceableCollection>(ofCount count: Int, or timer: AsyncTimerSequence<C>, into: Collected.Type) -> AsyncChunksOfCountOrSignalSequence<Self, Collected, AsyncTimerSequence<C>> where Collected.Element == Element {
+    AsyncChunksOfCountOrSignalSequence(self, count: count, signal: timer, produceEmptyChunks: false)
+  }
+
+  /// Creates an asynchronous sequence that creates chunks of a given count or when an `AsyncTimerSequence` fires.
+  @_disfavoredOverload
+  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+  @available(*, deprecated, renamed: "chunks(ofCount:or:produceEmptyChunks:)", message: "This method has been deprecated to allow the option for sequences to produce empty chunks.")
+  public func chunks<C: Clock>(ofCount count: Int, or timer: AsyncTimerSequence<C>) -> AsyncChunksOfCountOrSignalSequence<Self, [Element], AsyncTimerSequence<C>> {
+    chunks(ofCount: count, or: timer, into: [Element].self)
+  }
+
+  /// Creates an asynchronous sequence that creates chunks of a given `RangeReplaceableCollection` type when an `AsyncTimerSequence` fires.
+  @_disfavoredOverload
+  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+  @available(*, deprecated, renamed: "chunked(by:into:produceEmptyChunks:)", message: "This method has been deprecated to allow the option for sequences to produce empty chunks.")
+  public func chunked<C: Clock, Collected: RangeReplaceableCollection>(by timer: AsyncTimerSequence<C>, into: Collected.Type) -> AsyncChunksOfCountOrSignalSequence<Self, Collected, AsyncTimerSequence<C>> where Collected.Element == Element {
+    AsyncChunksOfCountOrSignalSequence(self, count: nil, signal: timer, produceEmptyChunks: false)
+  }
+
+  /// Creates an asynchronous sequence that creates chunks when an `AsyncTimerSequence` fires.
+  @_disfavoredOverload
+  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+  @available(*, deprecated, renamed: "chunked(by:produceEmptyChunks:)", message: "This method has been deprecated to allow the option for sequences to produce empty chunks.")
+  public func chunked<C: Clock>(by timer: AsyncTimerSequence<C>) -> AsyncChunksOfCountOrSignalSequence<Self, [Element], AsyncTimerSequence<C>> {
+    chunked(by: timer, into: [Element].self)
+  }
+}

--- a/Sources/AsyncSequenceValidation/Event.swift
+++ b/Sources/AsyncSequenceValidation/Event.swift
@@ -149,7 +149,11 @@ extension AsyncSequenceValidationDiagram {
             if grouping == 0 {
               when = when.advanced(by: .steps(1))
             }
-            emissions.append((when, .value(String(ch), index)))
+            if ch != "_" {
+              emissions.append((when, .value(String(ch), index)))
+            } else {
+              emissions.append((when, .value(String(), index)))
+            }
           } else {
             string?.append(str)
           }

--- a/Sources/AsyncSequenceValidation/Theme.swift
+++ b/Sources/AsyncSequenceValidation/Theme.swift
@@ -48,6 +48,7 @@ extension AsyncSequenceValidationDiagram {
       case "[": return .beginGroup
       case "]": return .endGroup
       case " ": return .skip
+      case "_": return .value(String())
       default: return .value(String(character))
       }
     }
@@ -64,7 +65,11 @@ extension AsyncSequenceValidationDiagram {
       case .beginGroup: return "["
       case .endGroup: return "]"
       case .skip: return " "
-      case .value(let value): return value
+      case .value(let value):
+        if value.count == 0 {
+          return "_"
+        }
+        return value
       }
     }
   }

--- a/Tests/AsyncAlgorithmsTests/TestChunk.swift
+++ b/Tests/AsyncAlgorithmsTests/TestChunk.swift
@@ -59,6 +59,15 @@ final class TestChunk: XCTestCase {
     }
   }
 
+  func test_signal_emptyChunks_produceEmptyChunks() {
+    validate {
+      "--1--|"
+      "XX-XX|"
+      $0.inputs[0].chunked(by: $0.inputs[1], produceEmptyChunks: true).map(concatCharacters)
+      "__-1_|"
+    }
+  }
+
   func test_signal_error() {
     validate {
       "AB^"
@@ -92,6 +101,15 @@ final class TestChunk: XCTestCase {
       "--   X----   X|"
       $0.inputs[0].chunks(ofCount: 2, or: $0.inputs[1]).map(concatCharacters)
       "-'AB'----'AB'-|"
+    }
+  }
+
+  func test_signalAndCount_countAlwaysPrevails_produceEmptyChunks() {
+    validate {
+      "AB   --A-B   -|"
+      "--   X----   X|"
+      $0.inputs[0].chunks(ofCount: 2, or: $0.inputs[1], produceEmptyChunks: true).map(concatCharacters)
+      "-'AB'_---'AB'_|"
     }
   }
 
@@ -149,6 +167,15 @@ final class TestChunk: XCTestCase {
     }
   }
 
+  func test_time_emptyChunks_produceEmptyChunks() throws {
+    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
+    validate {
+      "-- 1- --|"
+      $0.inputs[0].chunked(by: .repeating(every: .steps(2), clock: $0.clock), produceEmptyChunks: true).map(concatCharacters)
+      "-_ -1 -_|"
+    }
+  }
+
   func test_time_error() throws {
     guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
@@ -185,12 +212,30 @@ final class TestChunk: XCTestCase {
     }
   }
 
+  func test_timeAndCount_countAlwaysPrevails_produceEmptyChunks() throws {
+    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
+    validate {
+      "AB   --A-B   -|"
+      $0.inputs[0].chunks(ofCount: 2, or: .repeating(every: .steps(8), clock: $0.clock), produceEmptyChunks: true).map(concatCharacters)
+      "-'AB'----'AB'_|"
+    }
+  }
+
   func test_timeAndCount_countResetsAfterCount() throws {
     guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
     validate {
       "ABCDE      --- ABCDE      |"
       $0.inputs[0].chunks(ofCount: 5, or: .repeating(every: .steps(8), clock: $0.clock)).map(concatCharacters)
       "----'ABCDE'--- ----'ABCDE'|"
+    }
+  }
+
+  func test_timeAndCount_countResetsAfterCount_produceEmptyChunks() throws {
+    guard #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) else { throw XCTSkip("Skipped due to Clock/Instant/Duration availability") }
+    validate {
+      "ABCDE      --- ABCDE      |"
+      $0.inputs[0].chunks(ofCount: 5, or: .repeating(every: .steps(8), clock: $0.clock), produceEmptyChunks: true).map(concatCharacters)
+      "----'ABCDE'--_ ----'ABCDE'|"
     }
   }
 


### PR DESCRIPTION
async chunked sequences can produce empty chunks if signals are received before primary chunk elements.

This commit also includes an accompanying evolution proposal.