### PR TITLE
Bump swift-collections to 1.1.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -51,7 +51,7 @@ let package = Package(
 
 if Context.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
   package.dependencies += [
-    .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
+    .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.1"),
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
   ]
 } else {


### PR DESCRIPTION
## Information

- Package version: 1.0.1
- Swift version: 5.10

### Behavior

The app upload to App Store Connect fails due to swift-collections, when not using `SWIFTCI_USE_LOCAL_DEPS`.
This issue has been reported in https://github.com/apple/swift-collections/issues/364.
This package needs to be updated to version 1.1.1. 