### PR TITLE
Use Bionic module from new Android overlay in Swift 6 instead

### DIFF
--- a/Sources/AsyncAlgorithms/Locking.swift
+++ b/Sources/AsyncAlgorithms/Locking.swift
@@ -17,6 +17,8 @@ import Glibc
 import Musl
 #elseif canImport(WinSDK)
 import WinSDK
+#elseif canImport(Bionic)
+import Bionic
 #else
 #error("Unsupported platform")
 #endif
@@ -24,7 +26,7 @@ import WinSDK
 internal struct Lock {
 #if canImport(Darwin)
   typealias Primitive = os_unfair_lock
-#elseif canImport(Glibc) || canImport(Musl)
+#elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic)
   typealias Primitive = pthread_mutex_t
 #elseif canImport(WinSDK)
   typealias Primitive = SRWLOCK
@@ -42,7 +44,7 @@ internal struct Lock {
   fileprivate static func initialize(_ platformLock: PlatformLock) {
 #if canImport(Darwin)
     platformLock.initialize(to: os_unfair_lock())
-#elseif canImport(Glibc) || canImport(Musl)
+#elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic)
     let result = pthread_mutex_init(platformLock, nil)
     precondition(result == 0, "pthread_mutex_init failed")
 #elseif canImport(WinSDK)
@@ -53,7 +55,7 @@ internal struct Lock {
   }
   
   fileprivate static func deinitialize(_ platformLock: PlatformLock) {
-#if canImport(Glibc) || canImport(Musl)
+#if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
     let result = pthread_mutex_destroy(platformLock)
     precondition(result == 0, "pthread_mutex_destroy failed")
 #endif
@@ -63,7 +65,7 @@ internal struct Lock {
   fileprivate static func lock(_ platformLock: PlatformLock) {
 #if canImport(Darwin)
     os_unfair_lock_lock(platformLock)
-#elseif canImport(Glibc) || canImport(Musl)
+#elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic)
     pthread_mutex_lock(platformLock)
 #elseif canImport(WinSDK)
     AcquireSRWLockExclusive(platformLock)
@@ -75,7 +77,7 @@ internal struct Lock {
   fileprivate static func unlock(_ platformLock: PlatformLock) {
 #if canImport(Darwin)
     os_unfair_lock_unlock(platformLock)
-#elseif canImport(Glibc) || canImport(Musl)
+#elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic)
     let result = pthread_mutex_unlock(platformLock)
     precondition(result == 0, "pthread_mutex_unlock failed")
 #elseif canImport(WinSDK)


### PR DESCRIPTION
The new module and overlay were merged into Swift 6 in swiftlang/swift#74758.

I've been building and testing this package natively on Android for some time, but the addition of nullability annotations to Bionic with NDK 26 last year and the new Android overlay in the Swift compiler this summer required these changes.