### PR TITLE
Fix memory leak in Lock

### DIFF
--- a/Sources/AsyncAlgorithms/Locking.swift
+++ b/Sources/AsyncAlgorithms/Locking.swift
@@ -95,6 +95,7 @@ internal struct Lock {
 
   func deinitialize() {
     Lock.deinitialize(platformLock)
+    platformLock.deallocate()
   }
 
   func lock() {


### PR DESCRIPTION
The platform lock is never deallocated, which results in a leak. Since the platform lock is owned by Lock, I thought it would be fine to make deallocation part of `deinitialize()` and not have a separate `deallocate()` function. Especially since initialization of the lock is also mixed into `allocate()` already.