### PR TITLE
Fix build failure on Swift Playground

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,6 @@
 // swift-tools-version: 6.2
 
+import Foundation
 import PackageDescription
 import CompilerPluginSupport
 
@@ -107,7 +108,7 @@ let package = Package(
   ]
 )
 
-if Context.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
+if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
   package.dependencies += [
     .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0")
   ]

--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -1,5 +1,6 @@
 // swift-tools-version: 5.8
 
+import Foundation
 import PackageDescription
 import CompilerPluginSupport
 
@@ -93,7 +94,7 @@ let package = Package(
   ]
 )
 
-if Context.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
+if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
   package.dependencies += [
     .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0")
   ]


### PR DESCRIPTION
fixes #316

The PR #311 introduced `Context.environment`, so that swift-async-algorithm can no longer be used in the Swift Playground.

However, `Context.environment` is [equivalent to `ProcessInfo.processInfo.environment`](https://github.com/swiftlang/swift-package-manager/blob/80b1e179bef19e6eb71b0d20b2cb471053ae1b2c/Sources/PackageLoading/ContextModel.swift#L24), so this is an unnecessary sacrifice.

This change is intended to fix that.