### PR TITLE
Move platform requirements to availability annotations

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,12 +4,6 @@ import PackageDescription
 
 let package = Package(
   name: "swift-async-algorithms",
-  platforms: [
-    .macOS("10.15"),
-    .iOS("13.0"),
-    .tvOS("13.0"),
-    .watchOS("6.0"),
-  ],
   products: [
     .library(name: "AsyncAlgorithms", targets: ["AsyncAlgorithms"])
   ],

--- a/Package@swift-5.7.swift
+++ b/Package@swift-5.7.swift
@@ -4,12 +4,6 @@ import PackageDescription
 
 let package = Package(
   name: "swift-async-algorithms",
-  platforms: [
-    .macOS("10.15"),
-    .iOS("13.0"),
-    .tvOS("13.0"),
-    .watchOS("6.0"),
-  ],
   products: [
     .library(name: "AsyncAlgorithms", targets: ["AsyncAlgorithms"]),
     .library(name: "AsyncSequenceValidation", targets: ["AsyncSequenceValidation"]),

--- a/Sources/AsyncAlgorithms/AsyncAdjacentPairsSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncAdjacentPairsSequence.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequence {
   /// An `AsyncSequence` that iterates over the adjacent pairs of the original
   /// original `AsyncSequence`.
@@ -35,6 +36,7 @@ extension AsyncSequence {
 /// An `AsyncSequence` that iterates over the adjacent pairs of the original
 /// `AsyncSequence`.
 @frozen
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct AsyncAdjacentPairsSequence<Base: AsyncSequence>: AsyncSequence {
   public typealias Element = (Base.Element, Base.Element)
 
@@ -83,6 +85,7 @@ public struct AsyncAdjacentPairsSequence<Base: AsyncSequence>: AsyncSequence {
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncAdjacentPairsSequence: Sendable where Base: Sendable, Base.Element: Sendable {}
 
 @available(*, unavailable)

--- a/Sources/AsyncAlgorithms/AsyncBufferedByteIterator.swift
+++ b/Sources/AsyncAlgorithms/AsyncBufferedByteIterator.swift
@@ -39,6 +39,7 @@
 ///     }
 ///
 ///
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct AsyncBufferedByteIterator: AsyncIteratorProtocol {
   public typealias Element = UInt8
   @usableFromInline var buffer: _AsyncBytesBuffer
@@ -68,6 +69,7 @@ public struct AsyncBufferedByteIterator: AsyncIteratorProtocol {
 extension AsyncBufferedByteIterator: Sendable {}
 
 @frozen @usableFromInline
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 internal struct _AsyncBytesBuffer {
   @usableFromInline
   final class Storage {

--- a/Sources/AsyncAlgorithms/AsyncChain2Sequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncChain2Sequence.swift
@@ -18,6 +18,7 @@
 /// - Returns: An asynchronous sequence that iterates first over the elements of `s1`, and
 ///   then over the elements of `s2`.
 @inlinable
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public func chain<Base1: AsyncSequence, Base2: AsyncSequence>(
   _ s1: Base1,
   _ s2: Base2
@@ -27,6 +28,7 @@ public func chain<Base1: AsyncSequence, Base2: AsyncSequence>(
 
 /// A concatenation of two asynchronous sequences with the same element type.
 @frozen
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct AsyncChain2Sequence<Base1: AsyncSequence, Base2: AsyncSequence> where Base1.Element == Base2.Element {
   @usableFromInline
   let base1: Base1
@@ -41,6 +43,7 @@ public struct AsyncChain2Sequence<Base1: AsyncSequence, Base2: AsyncSequence> wh
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncChain2Sequence: AsyncSequence {
   public typealias Element = Base1.Element
 
@@ -82,6 +85,7 @@ extension AsyncChain2Sequence: AsyncSequence {
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncChain2Sequence: Sendable where Base1: Sendable, Base2: Sendable {}
 
 @available(*, unavailable)

--- a/Sources/AsyncAlgorithms/AsyncChain3Sequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncChain3Sequence.swift
@@ -19,6 +19,7 @@
 /// - Returns: An asynchronous sequence that iterates first over the elements of `s1`, and
 ///   then over the elements of `s2`, and then over the elements of `s3`
 @inlinable
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public func chain<Base1: AsyncSequence, Base2: AsyncSequence, Base3: AsyncSequence>(
   _ s1: Base1,
   _ s2: Base2,
@@ -29,6 +30,7 @@ public func chain<Base1: AsyncSequence, Base2: AsyncSequence, Base3: AsyncSequen
 
 /// A concatenation of three asynchronous sequences with the same element type.
 @frozen
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct AsyncChain3Sequence<Base1: AsyncSequence, Base2: AsyncSequence, Base3: AsyncSequence>
 where Base1.Element == Base2.Element, Base1.Element == Base3.Element {
   @usableFromInline
@@ -48,6 +50,7 @@ where Base1.Element == Base2.Element, Base1.Element == Base3.Element {
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncChain3Sequence: AsyncSequence {
   public typealias Element = Base1.Element
 
@@ -99,6 +102,7 @@ extension AsyncChain3Sequence: AsyncSequence {
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncChain3Sequence: Sendable where Base1: Sendable, Base2: Sendable, Base3: Sendable {}
 
 @available(*, unavailable)

--- a/Sources/AsyncAlgorithms/AsyncChunkedByGroupSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncChunkedByGroupSequence.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequence {
   /// Creates an asynchronous sequence that creates chunks of a given `RangeReplaceableCollection`
   /// type by testing if elements belong in the same group.
@@ -51,6 +52,7 @@ extension AsyncSequence {
 ///      // [10, 20, 30]
 ///      // [10, 40, 40]
 ///      // [10, 20]
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct AsyncChunkedByGroupSequence<Base: AsyncSequence, Collected: RangeReplaceableCollection>: AsyncSequence
 where Collected.Element == Base.Element {
   public typealias Element = Collected
@@ -121,6 +123,7 @@ where Collected.Element == Base.Element {
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncChunkedByGroupSequence: Sendable where Base: Sendable, Base.Element: Sendable {}
 
 @available(*, unavailable)

--- a/Sources/AsyncAlgorithms/AsyncChunkedOnProjectionSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncChunkedOnProjectionSequence.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequence {
   /// Creates an asynchronous sequence that creates chunks of a given `RangeReplaceableCollection` type on the uniqueness of a given subject.
   @inlinable
@@ -29,6 +30,7 @@ extension AsyncSequence {
 }
 
 /// An `AsyncSequence` that chunks on a subject when it differs from the last element.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct AsyncChunkedOnProjectionSequence<
   Base: AsyncSequence,
   Subject: Equatable,
@@ -104,6 +106,7 @@ public struct AsyncChunkedOnProjectionSequence<
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncChunkedOnProjectionSequence: Sendable where Base: Sendable, Base.Element: Sendable {}
 
 @available(*, unavailable)

--- a/Sources/AsyncAlgorithms/AsyncChunksOfCountOrSignalSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncChunksOfCountOrSignalSequence.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequence {
   /// Creates an asynchronous sequence that creates chunks of a given `RangeReplaceableCollection` type of a given count or when a signal `AsyncSequence` produces an element.
   public func chunks<Signal, Collected: RangeReplaceableCollection>(
@@ -78,6 +79,7 @@ extension AsyncSequence {
 }
 
 /// An `AsyncSequence` that chunks elements into collected `RangeReplaceableCollection` instances by either count or a signal from another `AsyncSequence`.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct AsyncChunksOfCountOrSignalSequence<
   Base: AsyncSequence,
   Collected: RangeReplaceableCollection,

--- a/Sources/AsyncAlgorithms/AsyncChunksOfCountSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncChunksOfCountSequence.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequence {
   /// Creates an asynchronous sequence that creates chunks of a given `RangeReplaceableCollection` of a given count.
   @inlinable
@@ -27,6 +28,7 @@ extension AsyncSequence {
 }
 
 /// An `AsyncSequence` that chunks elements into `RangeReplaceableCollection` instances of at least a given count.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct AsyncChunksOfCountSequence<Base: AsyncSequence, Collected: RangeReplaceableCollection>: AsyncSequence
 where Collected.Element == Base.Element {
   public typealias Element = Collected
@@ -89,8 +91,14 @@ where Collected.Element == Base.Element {
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncChunksOfCountSequence: Sendable where Base: Sendable, Base.Element: Sendable {}
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncChunksOfCountSequence.Iterator: Sendable where Base.AsyncIterator: Sendable, Base.Element: Sendable {}
 
-@available(*, unavailable)
-extension AsyncChunksOfCountSequence.Iterator: Sendable {}
+// The following conflicts with the above conformance. The compiler is okay with this
+// when 'platforms' are specified in the package manifest but not when the @available
+// attribute is used instead.
+//
+// @available(*, unavailable)
+// extension AsyncChunksOfCountSequence.Iterator: Sendable { }

--- a/Sources/AsyncAlgorithms/AsyncCompactedSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncCompactedSequence.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequence {
   /// Returns a new `AsyncSequence` that iterates over every non-nil element from the
   /// original `AsyncSequence`.
@@ -28,6 +29,7 @@ extension AsyncSequence {
 /// An `AsyncSequence` that iterates over every non-nil element from the original
 /// `AsyncSequence`.
 @frozen
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct AsyncCompactedSequence<Base: AsyncSequence, Element>: AsyncSequence
 where Base.Element == Element? {
 
@@ -66,6 +68,7 @@ where Base.Element == Element? {
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncCompactedSequence: Sendable where Base: Sendable, Base.Element: Sendable {}
 
 @available(*, unavailable)

--- a/Sources/AsyncAlgorithms/AsyncExclusiveReductionsSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncExclusiveReductionsSequence.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequence {
   /// Returns an asynchronous sequence containing the accumulated results of combining the
   /// elements of the asynchronous sequence using the given closure.
@@ -57,6 +58,7 @@ extension AsyncSequence {
 /// An asynchronous sequence of applying a transform to the element of an asynchronous sequence and the
 /// previously transformed result.
 @frozen
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct AsyncExclusiveReductionsSequence<Base: AsyncSequence, Element> {
   @usableFromInline
   let base: Base
@@ -75,6 +77,7 @@ public struct AsyncExclusiveReductionsSequence<Base: AsyncSequence, Element> {
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncExclusiveReductionsSequence: AsyncSequence {
   /// The iterator for an `AsyncExclusiveReductionsSequence` instance.
   @frozen
@@ -119,6 +122,7 @@ extension AsyncExclusiveReductionsSequence: AsyncSequence {
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncExclusiveReductionsSequence: Sendable where Base: Sendable, Element: Sendable {}
 
 @available(*, unavailable)

--- a/Sources/AsyncAlgorithms/AsyncInclusiveReductionsSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncInclusiveReductionsSequence.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequence {
   /// Returns an asynchronous sequence containing the accumulated results of combining the
   /// elements of the asynchronous sequence using the given closure.
@@ -39,6 +40,7 @@ extension AsyncSequence {
 /// An asynchronous sequence containing the accumulated results of combining the
 /// elements of the asynchronous sequence using a given closure.
 @frozen
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct AsyncInclusiveReductionsSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -53,6 +55,7 @@ public struct AsyncInclusiveReductionsSequence<Base: AsyncSequence> {
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncInclusiveReductionsSequence: AsyncSequence {
   public typealias Element = Base.Element
 
@@ -95,6 +98,7 @@ extension AsyncInclusiveReductionsSequence: AsyncSequence {
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncInclusiveReductionsSequence: Sendable where Base: Sendable {}
 
 @available(*, unavailable)

--- a/Sources/AsyncAlgorithms/AsyncJoinedBySeparatorSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncJoinedBySeparatorSequence.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequence where Element: AsyncSequence {
   /// Concatenate an `AsyncSequence` of `AsyncSequence` elements with a separator.
   @inlinable
@@ -20,6 +21,7 @@ extension AsyncSequence where Element: AsyncSequence {
 }
 
 /// An `AsyncSequence` that concatenates `AsyncSequence` elements with a separator.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct AsyncJoinedBySeparatorSequence<Base: AsyncSequence, Separator: AsyncSequence>: AsyncSequence
 where Base.Element: AsyncSequence, Separator.Element == Base.Element.Element {
   public typealias Element = Base.Element.Element
@@ -143,6 +145,7 @@ where Base.Element: AsyncSequence, Separator.Element == Base.Element.Element {
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncJoinedBySeparatorSequence: Sendable
 where Base: Sendable, Base.Element: Sendable, Base.Element.Element: Sendable, Separator: Sendable {}
 

--- a/Sources/AsyncAlgorithms/AsyncJoinedSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncJoinedSequence.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequence where Element: AsyncSequence {
   /// Concatenate an `AsyncSequence` of `AsyncSequence` elements
   @inlinable
@@ -19,6 +20,7 @@ extension AsyncSequence where Element: AsyncSequence {
 
 /// An `AsyncSequence` that concatenates`AsyncSequence` elements
 @frozen
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct AsyncJoinedSequence<Base: AsyncSequence>: AsyncSequence where Base.Element: AsyncSequence {
   public typealias Element = Base.Element.Element
   public typealias AsyncIterator = Iterator
@@ -90,6 +92,7 @@ public struct AsyncJoinedSequence<Base: AsyncSequence>: AsyncSequence where Base
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncJoinedSequence: Sendable
 where Base: Sendable, Base.Element: Sendable, Base.Element.Element: Sendable {}
 

--- a/Sources/AsyncAlgorithms/AsyncRemoveDuplicatesSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncRemoveDuplicatesSequence.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequence where Element: Equatable {
   /// Creates an asynchronous sequence that omits repeated elements.
   public func removeDuplicates() -> AsyncRemoveDuplicatesSequence<Self> {
@@ -18,6 +19,7 @@ extension AsyncSequence where Element: Equatable {
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequence {
   /// Creates an asynchronous sequence that omits repeated elements by testing them with a predicate.
   public func removeDuplicates(
@@ -35,6 +37,7 @@ extension AsyncSequence {
 }
 
 /// An asynchronous sequence that omits repeated elements by testing them with a predicate.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct AsyncRemoveDuplicatesSequence<Base: AsyncSequence>: AsyncSequence {
   public typealias Element = Base.Element
 
@@ -90,6 +93,7 @@ public struct AsyncRemoveDuplicatesSequence<Base: AsyncSequence>: AsyncSequence 
 }
 
 /// An asynchronous sequence that omits repeated elements by testing them with an error-throwing predicate.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct AsyncThrowingRemoveDuplicatesSequence<Base: AsyncSequence>: AsyncSequence {
   public typealias Element = Base.Element
 
@@ -144,7 +148,9 @@ public struct AsyncThrowingRemoveDuplicatesSequence<Base: AsyncSequence>: AsyncS
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncRemoveDuplicatesSequence: Sendable where Base: Sendable, Base.Element: Sendable {}
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncThrowingRemoveDuplicatesSequence: Sendable where Base: Sendable, Base.Element: Sendable {}
 
 @available(*, unavailable)

--- a/Sources/AsyncAlgorithms/AsyncSyncSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncSyncSequence.swift
@@ -14,6 +14,7 @@ extension Sequence {
   /// but on which operations, such as `map` and `filter`, are
   /// implemented asynchronously.
   @inlinable
+  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   public var async: AsyncSyncSequence<Self> {
     AsyncSyncSequence(self)
   }
@@ -28,6 +29,7 @@ extension Sequence {
 /// This functions similarly to `LazySequence` by accessing elements sequentially
 /// in the iterator's `next()` method.
 @frozen
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct AsyncSyncSequence<Base: Sequence>: AsyncSequence {
   public typealias Element = Base.Element
 
@@ -65,6 +67,7 @@ public struct AsyncSyncSequence<Base: Sequence>: AsyncSequence {
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSyncSequence: Sendable where Base: Sendable {}
 
 @available(*, unavailable)

--- a/Sources/AsyncAlgorithms/AsyncThrottleSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncThrottleSequence.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequence {
   /// Create a rate-limited `AsyncSequence` by emitting values at most every specified interval.
   @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)

--- a/Sources/AsyncAlgorithms/AsyncThrowingExclusiveReductionsSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncThrowingExclusiveReductionsSequence.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequence {
   /// Returns an asynchronous sequence containing the accumulated results of combining the
   /// elements of the asynchronous sequence using the given error-throwing closure.
@@ -59,6 +60,7 @@ extension AsyncSequence {
 /// An asynchronous sequence of applying an error-throwing transform to the element of
 /// an asynchronous sequence and the previously transformed result.
 @frozen
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct AsyncThrowingExclusiveReductionsSequence<Base: AsyncSequence, Element> {
   @usableFromInline
   let base: Base
@@ -81,6 +83,7 @@ public struct AsyncThrowingExclusiveReductionsSequence<Base: AsyncSequence, Elem
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncThrowingExclusiveReductionsSequence: AsyncSequence {
   /// The iterator for an `AsyncThrowingExclusiveReductionsSequence` instance.
   @frozen
@@ -130,6 +133,7 @@ extension AsyncThrowingExclusiveReductionsSequence: AsyncSequence {
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncThrowingExclusiveReductionsSequence: Sendable where Base: Sendable, Element: Sendable {}
 
 @available(*, unavailable)

--- a/Sources/AsyncAlgorithms/AsyncThrowingInclusiveReductionsSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncThrowingInclusiveReductionsSequence.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequence {
   /// Returns an asynchronous sequence containing the accumulated results of combining the
   /// elements of the asynchronous sequence using the given error-throwing closure.
@@ -38,6 +39,7 @@ extension AsyncSequence {
 /// An asynchronous sequence containing the accumulated results of combining the
 /// elements of the asynchronous sequence using a given error-throwing closure.
 @frozen
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct AsyncThrowingInclusiveReductionsSequence<Base: AsyncSequence> {
   @usableFromInline
   let base: Base
@@ -52,6 +54,7 @@ public struct AsyncThrowingInclusiveReductionsSequence<Base: AsyncSequence> {
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncThrowingInclusiveReductionsSequence: AsyncSequence {
   public typealias Element = Base.Element
 
@@ -99,6 +102,7 @@ extension AsyncThrowingInclusiveReductionsSequence: AsyncSequence {
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncThrowingInclusiveReductionsSequence: Sendable where Base: Sendable {}
 
 @available(*, unavailable)

--- a/Sources/AsyncAlgorithms/Buffer/AsyncBufferSequence.swift
+++ b/Sources/AsyncAlgorithms/Buffer/AsyncBufferSequence.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequence where Self: Sendable {
   /// Creates an asynchronous sequence that buffers elements.
   ///
@@ -69,6 +70,7 @@ public struct AsyncBufferSequencePolicy: Sendable {
 }
 
 /// An `AsyncSequence` that buffers elements in regard to a policy.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct AsyncBufferSequence<Base: AsyncSequence & Sendable>: AsyncSequence {
   enum StorageType {
     case transparent(Base.AsyncIterator)
@@ -125,6 +127,7 @@ public struct AsyncBufferSequence<Base: AsyncSequence & Sendable>: AsyncSequence
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncBufferSequence: Sendable where Base: Sendable {}
 
 @available(*, unavailable)

--- a/Sources/AsyncAlgorithms/Buffer/BoundedBufferStateMachine.swift
+++ b/Sources/AsyncAlgorithms/Buffer/BoundedBufferStateMachine.swift
@@ -11,6 +11,7 @@
 
 import DequeModule
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 struct BoundedBufferStateMachine<Base: AsyncSequence> {
   typealias Element = Base.Element
   typealias SuspendedProducer = UnsafeContinuation<Void, Never>
@@ -322,5 +323,7 @@ struct BoundedBufferStateMachine<Base: AsyncSequence> {
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension BoundedBufferStateMachine: Sendable where Base: Sendable {}
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension BoundedBufferStateMachine.State: Sendable where Base: Sendable {}

--- a/Sources/AsyncAlgorithms/Buffer/BoundedBufferStorage.swift
+++ b/Sources/AsyncAlgorithms/Buffer/BoundedBufferStorage.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class BoundedBufferStorage<Base: AsyncSequence>: Sendable where Base: Sendable {
   private let stateMachine: ManagedCriticalState<BoundedBufferStateMachine<Base>>
 

--- a/Sources/AsyncAlgorithms/Buffer/UnboundedBufferStateMachine.swift
+++ b/Sources/AsyncAlgorithms/Buffer/UnboundedBufferStateMachine.swift
@@ -11,6 +11,7 @@
 
 import DequeModule
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 struct UnboundedBufferStateMachine<Base: AsyncSequence> {
   typealias Element = Base.Element
   typealias SuspendedConsumer = UnsafeContinuation<Result<Element, Error>?, Never>
@@ -252,5 +253,7 @@ struct UnboundedBufferStateMachine<Base: AsyncSequence> {
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension UnboundedBufferStateMachine: Sendable where Base: Sendable {}
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension UnboundedBufferStateMachine.State: Sendable where Base: Sendable {}

--- a/Sources/AsyncAlgorithms/Buffer/UnboundedBufferStorage.swift
+++ b/Sources/AsyncAlgorithms/Buffer/UnboundedBufferStorage.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class UnboundedBufferStorage<Base: AsyncSequence>: Sendable where Base: Sendable {
   private let stateMachine: ManagedCriticalState<UnboundedBufferStateMachine<Base>>
 

--- a/Sources/AsyncAlgorithms/Channels/AsyncChannel.swift
+++ b/Sources/AsyncAlgorithms/Channels/AsyncChannel.swift
@@ -19,6 +19,7 @@
 /// on the `Iterator` is made, or when `finish()` is called from another Task.
 /// As `finish()` induces a terminal state, there is no more need for a back pressure management.
 /// This function does not suspend and will finish all the pending iterations.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public final class AsyncChannel<Element: Sendable>: AsyncSequence, Sendable {
   public typealias Element = Element
   public typealias AsyncIterator = Iterator

--- a/Sources/AsyncAlgorithms/Channels/AsyncThrowingChannel.swift
+++ b/Sources/AsyncAlgorithms/Channels/AsyncThrowingChannel.swift
@@ -18,6 +18,7 @@
 /// and is resumed when the next call to `next()` on the `Iterator` is made, or when `finish()`/`fail(_:)` is called
 /// from another Task. As `finish()` and `fail(_:)` induce a terminal state, there is no more need for a back pressure management.
 /// Those functions do not suspend and will finish all the pending iterations.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public final class AsyncThrowingChannel<Element: Sendable, Failure: Error>: AsyncSequence, Sendable {
   public typealias Element = Element
   public typealias AsyncIterator = Iterator

--- a/Sources/AsyncAlgorithms/Channels/ChannelStateMachine.swift
+++ b/Sources/AsyncAlgorithms/Channels/ChannelStateMachine.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 import OrderedCollections
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 struct ChannelStateMachine<Element: Sendable, Failure: Error>: Sendable {
   private struct SuspendedProducer: Hashable, Sendable {
     let id: UInt64

--- a/Sources/AsyncAlgorithms/Channels/ChannelStorage.swift
+++ b/Sources/AsyncAlgorithms/Channels/ChannelStorage.swift
@@ -8,6 +8,7 @@
 // See https://swift.org/LICENSE.txt for license information
 //
 //===----------------------------------------------------------------------===//
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 struct ChannelStorage<Element: Sendable, Failure: Error>: Sendable {
   private let stateMachine: ManagedCriticalState<ChannelStateMachine<Element, Failure>>
   private let ids = ManagedCriticalState<UInt64>(0)

--- a/Sources/AsyncAlgorithms/CombineLatest/AsyncCombineLatest2Sequence.swift
+++ b/Sources/AsyncAlgorithms/CombineLatest/AsyncCombineLatest2Sequence.swift
@@ -20,6 +20,7 @@
 /// Throws:
 /// ``combineLatest(_:_:)`` throws when one of the bases throws. If one of the bases threw any buffered and not yet consumed
 /// values will be dropped.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public func combineLatest<
   Base1: AsyncSequence,
   Base2: AsyncSequence
@@ -34,6 +35,7 @@ where
 }
 
 /// An `AsyncSequence` that combines the latest values produced from two asynchronous sequences into an asynchronous sequence of tuples.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct AsyncCombineLatest2Sequence<
   Base1: AsyncSequence,
   Base2: AsyncSequence

--- a/Sources/AsyncAlgorithms/CombineLatest/AsyncCombineLatest3Sequence.swift
+++ b/Sources/AsyncAlgorithms/CombineLatest/AsyncCombineLatest3Sequence.swift
@@ -20,6 +20,7 @@
 /// Throws:
 /// ``combineLatest(_:_:_:)`` throws when one of the bases throws. If one of the bases threw any buffered and not yet consumed
 /// values will be dropped.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public func combineLatest<
   Base1: AsyncSequence,
   Base2: AsyncSequence,
@@ -37,6 +38,7 @@ where
 }
 
 /// An `AsyncSequence` that combines the latest values produced from three asynchronous sequences into an asynchronous sequence of tuples.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct AsyncCombineLatest3Sequence<
   Base1: AsyncSequence,
   Base2: AsyncSequence,

--- a/Sources/AsyncAlgorithms/CombineLatest/CombineLatestStateMachine.swift
+++ b/Sources/AsyncAlgorithms/CombineLatest/CombineLatestStateMachine.swift
@@ -12,6 +12,7 @@
 import DequeModule
 
 /// State machine for combine latest
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 struct CombineLatestStateMachine<
   Base1: AsyncSequence,
   Base2: AsyncSequence,

--- a/Sources/AsyncAlgorithms/CombineLatest/CombineLatestStorage.swift
+++ b/Sources/AsyncAlgorithms/CombineLatest/CombineLatestStorage.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class CombineLatestStorage<
   Base1: AsyncSequence,
   Base2: AsyncSequence,

--- a/Sources/AsyncAlgorithms/Debounce/AsyncDebounceSequence.swift
+++ b/Sources/AsyncAlgorithms/Debounce/AsyncDebounceSequence.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequence {
   /// Creates an asynchronous sequence that emits the latest element after a given quiescence period
   /// has elapsed by using a specified Clock.

--- a/Sources/AsyncAlgorithms/Dictionary.swift
+++ b/Sources/AsyncAlgorithms/Dictionary.swift
@@ -22,6 +22,7 @@ extension Dictionary {
   ///   the new dictionary. Every key in `keysAndValues` must be unique.
   /// - Precondition: The sequence must not have duplicate keys.
   @inlinable
+  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   public init<S: AsyncSequence>(uniqueKeysWithValues keysAndValues: S) async rethrows
   where S.Element == (Key, Value) {
     self.init(uniqueKeysWithValues: try await Array(keysAndValues))
@@ -46,6 +47,7 @@ extension Dictionary {
   ///     the final dictionary, or throws an error if building the dictionary
   ///     can't proceed.
   @inlinable
+  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   public init<S: AsyncSequence>(
     _ keysAndValues: S,
     uniquingKeysWith combine: (Value, Value) async throws -> Value
@@ -73,6 +75,7 @@ extension Dictionary {
   ///   - keyForValue: A closure that returns a key for each element in
   ///     `values`.
   @inlinable
+  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   public init<S: AsyncSequence>(grouping values: S, by keyForValue: (S.Element) async throws -> Key) async rethrows
   where Value == [S.Element] {
     self.init()

--- a/Sources/AsyncAlgorithms/Interspersed/AsyncInterspersedSequence.swift
+++ b/Sources/AsyncAlgorithms/Interspersed/AsyncInterspersedSequence.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequence {
   /// Returns a new asynchronous sequence containing the elements of this asynchronous sequence, inserting
   /// the given separator between each element.
@@ -150,6 +151,7 @@ extension AsyncSequence {
 
 /// An asynchronous sequence that presents the elements of a base asynchronous sequence of
 /// elements with a separator between each of those elements.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct AsyncInterspersedSequence<Base: AsyncSequence> {
   @usableFromInline
   internal enum Separator {
@@ -192,6 +194,7 @@ public struct AsyncInterspersedSequence<Base: AsyncSequence> {
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncInterspersedSequence: AsyncSequence {
   public typealias Element = Base.Element
 
@@ -301,6 +304,7 @@ extension AsyncInterspersedSequence: AsyncSequence {
 
 /// An asynchronous sequence that presents the elements of a base asynchronous sequence of
 /// elements with a separator between each of those elements.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct AsyncThrowingInterspersedSequence<Base: AsyncSequence> {
   @usableFromInline
   internal enum Separator {
@@ -334,6 +338,7 @@ public struct AsyncThrowingInterspersedSequence<Base: AsyncSequence> {
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncThrowingInterspersedSequence: AsyncSequence {
   public typealias Element = Base.Element
 
@@ -438,10 +443,14 @@ extension AsyncThrowingInterspersedSequence: AsyncSequence {
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncInterspersedSequence: Sendable where Base: Sendable, Base.Element: Sendable {}
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncInterspersedSequence.Separator: Sendable where Base: Sendable, Base.Element: Sendable {}
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncThrowingInterspersedSequence: Sendable where Base: Sendable, Base.Element: Sendable {}
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncThrowingInterspersedSequence.Separator: Sendable where Base: Sendable, Base.Element: Sendable {}
 
 @available(*, unavailable)

--- a/Sources/AsyncAlgorithms/Merge/AsyncMerge2Sequence.swift
+++ b/Sources/AsyncAlgorithms/Merge/AsyncMerge2Sequence.swift
@@ -12,6 +12,7 @@
 import DequeModule
 
 /// Creates an asynchronous sequence of elements from two underlying asynchronous sequences
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public func merge<Base1: AsyncSequence, Base2: AsyncSequence>(
   _ base1: Base1,
   _ base2: Base2
@@ -26,6 +27,7 @@ where
 }
 
 /// An `AsyncSequence` that takes two upstream `AsyncSequence`s and combines their elements.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct AsyncMerge2Sequence<
   Base1: AsyncSequence,
   Base2: AsyncSequence
@@ -55,6 +57,7 @@ where
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncMerge2Sequence: AsyncSequence {
   public func makeAsyncIterator() -> Iterator {
     let storage = MergeStorage<Base1, Base2, Base1>(
@@ -66,6 +69,7 @@ extension AsyncMerge2Sequence: AsyncSequence {
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncMerge2Sequence {
   public struct Iterator: AsyncIteratorProtocol {
     /// This class is needed to hook the deinit to observe once all references to the ``AsyncIterator`` are dropped.

--- a/Sources/AsyncAlgorithms/Merge/AsyncMerge3Sequence.swift
+++ b/Sources/AsyncAlgorithms/Merge/AsyncMerge3Sequence.swift
@@ -12,6 +12,7 @@
 import DequeModule
 
 /// Creates an asynchronous sequence of elements from two underlying asynchronous sequences
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public func merge<
   Base1: AsyncSequence,
   Base2: AsyncSequence,
@@ -29,6 +30,7 @@ where
 }
 
 /// An `AsyncSequence` that takes three upstream `AsyncSequence`s and combines their elements.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct AsyncMerge3Sequence<
   Base1: AsyncSequence,
   Base2: AsyncSequence,
@@ -65,6 +67,7 @@ where
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncMerge3Sequence: AsyncSequence {
   public func makeAsyncIterator() -> Iterator {
     let storage = MergeStorage(
@@ -76,6 +79,7 @@ extension AsyncMerge3Sequence: AsyncSequence {
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncMerge3Sequence {
   public struct Iterator: AsyncIteratorProtocol {
     /// This class is needed to hook the deinit to observe once all references to the ``AsyncIterator`` are dropped.

--- a/Sources/AsyncAlgorithms/Merge/MergeStateMachine.swift
+++ b/Sources/AsyncAlgorithms/Merge/MergeStateMachine.swift
@@ -15,6 +15,7 @@ import DequeModule
 ///
 /// Right now this state machine supports 3 upstream `AsyncSequences`; however, this can easily be extended.
 /// Once variadic generic land we should migrate this to use them instead.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 struct MergeStateMachine<
   Base1: AsyncSequence,
   Base2: AsyncSequence,

--- a/Sources/AsyncAlgorithms/Merge/MergeStorage.swift
+++ b/Sources/AsyncAlgorithms/Merge/MergeStorage.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class MergeStorage<
   Base1: AsyncSequence,
   Base2: AsyncSequence,

--- a/Sources/AsyncAlgorithms/RangeReplaceableCollection.swift
+++ b/Sources/AsyncAlgorithms/RangeReplaceableCollection.swift
@@ -14,6 +14,7 @@ extension RangeReplaceableCollection {
   ///
   /// - Parameter source: The asynchronous sequence of elements for the new collection.
   @inlinable
+  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   public init<Source: AsyncSequence>(_ source: Source) async rethrows where Source.Element == Element {
     self.init()
     for try await item in source {

--- a/Sources/AsyncAlgorithms/SetAlgebra.swift
+++ b/Sources/AsyncAlgorithms/SetAlgebra.swift
@@ -16,6 +16,7 @@ extension SetAlgebra {
   ///
   /// - Parameter source: The elements to use as members of the new set.
   @inlinable
+  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   public init<Source: AsyncSequence>(_ source: Source) async rethrows where Source.Element == Element {
     self.init()
     for try await item in source {

--- a/Sources/AsyncAlgorithms/Zip/AsyncZip2Sequence.swift
+++ b/Sources/AsyncAlgorithms/Zip/AsyncZip2Sequence.swift
@@ -11,6 +11,7 @@
 
 /// Creates an asynchronous sequence that concurrently awaits values from two `AsyncSequence` types
 /// and emits a tuple of the values.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public func zip<Base1: AsyncSequence, Base2: AsyncSequence>(
   _ base1: Base1,
   _ base2: Base2
@@ -20,6 +21,7 @@ public func zip<Base1: AsyncSequence, Base2: AsyncSequence>(
 
 /// An asynchronous sequence that concurrently awaits values from two `AsyncSequence` types
 /// and emits a tuple of the values.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct AsyncZip2Sequence<Base1: AsyncSequence, Base2: AsyncSequence>: AsyncSequence, Sendable
 where Base1: Sendable, Base1.Element: Sendable, Base2: Sendable, Base2.Element: Sendable {
   public typealias Element = (Base1.Element, Base2.Element)

--- a/Sources/AsyncAlgorithms/Zip/AsyncZip3Sequence.swift
+++ b/Sources/AsyncAlgorithms/Zip/AsyncZip3Sequence.swift
@@ -11,6 +11,7 @@
 
 /// Creates an asynchronous sequence that concurrently awaits values from three `AsyncSequence` types
 /// and emits a tuple of the values.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public func zip<Base1: AsyncSequence, Base2: AsyncSequence, Base3: AsyncSequence>(
   _ base1: Base1,
   _ base2: Base2,
@@ -21,6 +22,7 @@ public func zip<Base1: AsyncSequence, Base2: AsyncSequence, Base3: AsyncSequence
 
 /// An asynchronous sequence that concurrently awaits values from three `AsyncSequence` types
 /// and emits a tuple of the values.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct AsyncZip3Sequence<Base1: AsyncSequence, Base2: AsyncSequence, Base3: AsyncSequence>: AsyncSequence,
   Sendable
 where

--- a/Sources/AsyncAlgorithms/Zip/ZipStateMachine.swift
+++ b/Sources/AsyncAlgorithms/Zip/ZipStateMachine.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 /// State machine for zip
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 struct ZipStateMachine<
   Base1: AsyncSequence,
   Base2: AsyncSequence,

--- a/Sources/AsyncAlgorithms/Zip/ZipStorage.swift
+++ b/Sources/AsyncAlgorithms/Zip/ZipStorage.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class ZipStorage<Base1: AsyncSequence, Base2: AsyncSequence, Base3: AsyncSequence>: Sendable
 where
   Base1: Sendable,

--- a/Sources/AsyncAlgorithms_XCTest/ValidationTest.swift
+++ b/Sources/AsyncAlgorithms_XCTest/ValidationTest.swift
@@ -33,6 +33,7 @@ extension XCTestCase {
     #endif
   }
 
+  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   func validate<Test: AsyncSequenceValidationTest, Theme: AsyncSequenceValidationTheme>(
     theme: Theme,
     expectedFailures: Set<String>,
@@ -77,6 +78,7 @@ extension XCTestCase {
     }
   }
 
+  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   func validate<Test: AsyncSequenceValidationTest>(
     expectedFailures: Set<String>,
     @AsyncSequenceValidationDiagram _ build: (AsyncSequenceValidationDiagram) -> Test,
@@ -86,6 +88,7 @@ extension XCTestCase {
     validate(theme: .ascii, expectedFailures: expectedFailures, build, file: file, line: line)
   }
 
+  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   public func validate<Test: AsyncSequenceValidationTest, Theme: AsyncSequenceValidationTheme>(
     theme: Theme,
     @AsyncSequenceValidationDiagram _ build: (AsyncSequenceValidationDiagram) -> Test,
@@ -95,6 +98,7 @@ extension XCTestCase {
     validate(theme: theme, expectedFailures: [], build, file: file, line: line)
   }
 
+  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
   public func validate<Test: AsyncSequenceValidationTest>(
     @AsyncSequenceValidationDiagram _ build: (AsyncSequenceValidationDiagram) -> Test,
     file: StaticString = #file,

--- a/Sources/AsyncSequenceValidation/AsyncSequenceValidationDiagram.swift
+++ b/Sources/AsyncSequenceValidation/AsyncSequenceValidationDiagram.swift
@@ -12,6 +12,7 @@
 import _CAsyncSequenceValidationSupport
 
 @resultBuilder
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct AsyncSequenceValidationDiagram: Sendable {
   public struct Component<T> {
     var component: T

--- a/Sources/AsyncSequenceValidation/Clock.swift
+++ b/Sources/AsyncSequenceValidation/Clock.swift
@@ -11,6 +11,7 @@
 
 import AsyncAlgorithms
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequenceValidationDiagram {
   public struct Clock {
     let queue: WorkQueue
@@ -21,6 +22,7 @@ extension AsyncSequenceValidationDiagram {
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public protocol TestClock: Sendable {
   associatedtype Instant: TestInstant
 
@@ -33,6 +35,7 @@ public protocol TestInstant: Equatable {
   associatedtype Duration
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequenceValidationDiagram.Clock {
   public struct Step: DurationProtocol, Hashable, CustomStringConvertible {
     internal var rawValue: Int
@@ -127,16 +130,20 @@ extension AsyncSequenceValidationDiagram.Clock {
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequenceValidationDiagram.Clock.Instant: TestInstant {}
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension AsyncSequenceValidationDiagram.Clock.Instant: InstantProtocol {}
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequenceValidationDiagram.Clock: TestClock {}
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension AsyncSequenceValidationDiagram.Clock: Clock {}
 
 // placeholders to avoid warnings
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequenceValidationDiagram.Clock.Instant: Hashable {}
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequenceValidationDiagram.Clock.Instant: Comparable {}

--- a/Sources/AsyncSequenceValidation/Event.swift
+++ b/Sources/AsyncSequenceValidation/Event.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequenceValidationDiagram {
   struct Failure: Error, Equatable {}
 

--- a/Sources/AsyncSequenceValidation/Expectation.swift
+++ b/Sources/AsyncSequenceValidation/Expectation.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequenceValidationDiagram {
   public struct ExpectationResult: Sendable {
     public struct Event: Sendable {

--- a/Sources/AsyncSequenceValidation/Input.swift
+++ b/Sources/AsyncSequenceValidation/Input.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequenceValidationDiagram {
   public struct Specification: Sendable {
     public let specification: String

--- a/Sources/AsyncSequenceValidation/Job.swift
+++ b/Sources/AsyncSequenceValidation/Job.swift
@@ -11,6 +11,7 @@
 
 import _CAsyncSequenceValidationSupport
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 struct Job: Hashable, @unchecked Sendable {
   let job: JobRef
 

--- a/Sources/AsyncSequenceValidation/TaskDriver.swift
+++ b/Sources/AsyncSequenceValidation/TaskDriver.swift
@@ -26,16 +26,19 @@ import Bionic
 #endif
 
 #if canImport(Darwin)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 func start_thread(_ raw: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer? {
   Unmanaged<TaskDriver>.fromOpaque(raw).takeRetainedValue().run()
   return nil
 }
 #elseif (canImport(Glibc) && !os(Android)) || canImport(Musl)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 func start_thread(_ raw: UnsafeMutableRawPointer?) -> UnsafeMutableRawPointer? {
   Unmanaged<TaskDriver>.fromOpaque(raw!).takeRetainedValue().run()
   return nil
 }
 #elseif os(Android)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 func start_thread(_ raw: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
   Unmanaged<TaskDriver>.fromOpaque(raw).takeRetainedValue().run()
   return UnsafeMutableRawPointer(bitPattern: 0xdeadbee)!
@@ -44,6 +47,7 @@ func start_thread(_ raw: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
 #error("TODO: Port TaskDriver threading to windows")
 #endif
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class TaskDriver {
   let work: (TaskDriver) -> Void
   let queue: WorkQueue

--- a/Sources/AsyncSequenceValidation/Test.swift
+++ b/Sources/AsyncSequenceValidation/Test.swift
@@ -14,11 +14,13 @@ import AsyncAlgorithms
 
 @_silgen_name("swift_job_run")
 @usableFromInline
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 internal func _swiftJobRun(
   _ job: UnownedJob,
   _ executor: UnownedSerialExecutor
 )
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public protocol AsyncSequenceValidationTest: Sendable {
   var inputs: [AsyncSequenceValidationDiagram.Specification] { get }
   var output: AsyncSequenceValidationDiagram.Specification { get }
@@ -31,6 +33,7 @@ public protocol AsyncSequenceValidationTest: Sendable {
   ) async throws
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequenceValidationDiagram {
   struct Test<Operation: AsyncSequence>: AsyncSequenceValidationTest, @unchecked Sendable
   where Operation.Element == String {

--- a/Sources/AsyncSequenceValidation/Theme.swift
+++ b/Sources/AsyncSequenceValidation/Theme.swift
@@ -9,18 +9,21 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public protocol AsyncSequenceValidationTheme {
   func token(_ character: Character, inValue: Bool) -> AsyncSequenceValidationDiagram.Token
 
   func description(for token: AsyncSequenceValidationDiagram.Token) -> String
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequenceValidationTheme where Self == AsyncSequenceValidationDiagram.ASCIITheme {
   public static var ascii: AsyncSequenceValidationDiagram.ASCIITheme {
     return AsyncSequenceValidationDiagram.ASCIITheme()
   }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequenceValidationDiagram {
   public enum Token: Sendable {
     case step

--- a/Sources/AsyncSequenceValidation/WorkQueue.swift
+++ b/Sources/AsyncSequenceValidation/WorkQueue.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 struct WorkQueue: Sendable {
   enum Item: CustomStringConvertible, Comparable {
     case blocked(Token, AsyncSequenceValidationDiagram.Clock.Instant, UnsafeContinuation<Void, Error>)


### PR DESCRIPTION
Adding or raising the deployment platforms in the package manifest is a SemVer major breaking change as consumers must also add or raise their deployment platforms. This is a known limitation of SwiftPM.

Unforunately this means that it's very difficult for non-leaf packages to adopt packages which declare their platforms in the manifest. Doing so puts the brakes on adoption and ecosystem growth. For 'core' packages like this one availability constraints should be expressed on declarations rather than in the manifest.

This patch adds equivalent availability annotations to declarations across the package and removes platforms from the package manifest.