### PR TITLE
Move platform requirements to availability annotations

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,15 +1,39 @@
 // swift-tools-version: 5.8
 
 import PackageDescription
+import CompilerPluginSupport
+
+// Availability Macros
+let availabilityTags = [_Availability("AsyncAlgorithms")]
+let versionNumbers = ["1.0"]
+
+// Availability Macro Utilities
+enum _OSAvailability: String {
+  // This should match the package's deployment target
+  case alwaysAvailable = "macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0"
+  // Use 10000 for future availability to avoid compiler magic around
+  // the 9999 version number but ensure it is greater than 9999
+  case future = "macOS 10000, iOS 10000, tvOS 10000, watchOS 10000"
+}
+
+struct _Availability {
+  let name: String
+  let osAvailability: _OSAvailability
+
+  init(_ name: String, availability: _OSAvailability = .alwaysAvailable) {
+    self.name = name
+    self.osAvailability = availability
+  }
+}
+
+let availabilityMacros: [SwiftSetting] = versionNumbers.flatMap { version in
+  availabilityTags.map {
+    .enableExperimentalFeature("AvailabilityMacro=\($0.name) \(version):\($0.osAvailability.rawValue)")
+  }
+}
 
 let package = Package(
   name: "swift-async-algorithms",
-  platforms: [
-    .macOS("10.15"),
-    .iOS("13.0"),
-    .tvOS("13.0"),
-    .watchOS("6.0"),
-  ],
   products: [
     .library(name: "AsyncAlgorithms", targets: ["AsyncAlgorithms"])
   ],
@@ -20,14 +44,14 @@ let package = Package(
         .product(name: "OrderedCollections", package: "swift-collections"),
         .product(name: "DequeModule", package: "swift-collections"),
       ],
-      swiftSettings: [
+      swiftSettings: availabilityMacros + [
         .enableExperimentalFeature("StrictConcurrency=complete")
       ]
     ),
     .target(
       name: "AsyncSequenceValidation",
       dependencies: ["_CAsyncSequenceValidationSupport", "AsyncAlgorithms"],
-      swiftSettings: [
+      swiftSettings: availabilityMacros + [
         .enableExperimentalFeature("StrictConcurrency=complete")
       ]
     ),
@@ -35,14 +59,14 @@ let package = Package(
     .target(
       name: "AsyncAlgorithms_XCTest",
       dependencies: ["AsyncAlgorithms", "AsyncSequenceValidation"],
-      swiftSettings: [
+      swiftSettings: availabilityMacros + [
         .enableExperimentalFeature("StrictConcurrency=complete")
       ]
     ),
     .testTarget(
       name: "AsyncAlgorithmsTests",
       dependencies: ["AsyncAlgorithms", "AsyncSequenceValidation", "AsyncAlgorithms_XCTest"],
-      swiftSettings: [
+      swiftSettings: availabilityMacros + [
         .enableExperimentalFeature("StrictConcurrency=complete")
       ]
     ),

--- a/Package.swift
+++ b/Package.swift
@@ -4,23 +4,24 @@ import PackageDescription
 import CompilerPluginSupport
 
 // Availability Macros
-let availabilityTags = [_Availability("AsyncAlgorithms")]
+let availabilityTags = [Availability("AsyncAlgorithms")]
 let versionNumbers = ["1.0"]
 
 // Availability Macro Utilities
-enum _OSAvailability: String {
+enum OSAvailability: String {
   // This should match the package's deployment target
-  case alwaysAvailable = "macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0"
+  case initialIntroduction = "macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0"
+  case pending = "macOS 9999, iOS 9999, tvOS 9999, watchOS 9999"
   // Use 10000 for future availability to avoid compiler magic around
   // the 9999 version number but ensure it is greater than 9999
   case future = "macOS 10000, iOS 10000, tvOS 10000, watchOS 10000"
 }
 
-struct _Availability {
+struct Availability {
   let name: String
-  let osAvailability: _OSAvailability
+  let osAvailability: OSAvailability
 
-  init(_ name: String, availability: _OSAvailability = .alwaysAvailable) {
+  init(_ name: String, availability: OSAvailability = .initialIntroduction) {
     self.name = name
     self.osAvailability = availability
   }

--- a/Sources/AsyncAlgorithms/AsyncAdjacentPairsSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncAdjacentPairsSequence.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSequence {
   /// An `AsyncSequence` that iterates over the adjacent pairs of the original
   /// original `AsyncSequence`.
@@ -26,6 +27,7 @@ extension AsyncSequence {
   ///
   /// - Returns: An `AsyncSequence` where the element is a tuple of two adjacent elements
   ///   or the original `AsyncSequence`.
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func adjacentPairs() -> AsyncAdjacentPairsSequence<Self> {
     AsyncAdjacentPairsSequence(self)
@@ -34,6 +36,7 @@ extension AsyncSequence {
 
 /// An `AsyncSequence` that iterates over the adjacent pairs of the original
 /// `AsyncSequence`.
+@available(AsyncAlgorithms 1.0, *)
 @frozen
 public struct AsyncAdjacentPairsSequence<Base: AsyncSequence>: AsyncSequence {
   public typealias Element = (Base.Element, Base.Element)
@@ -83,6 +86,7 @@ public struct AsyncAdjacentPairsSequence<Base: AsyncSequence>: AsyncSequence {
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncAdjacentPairsSequence: Sendable where Base: Sendable, Base.Element: Sendable {}
 
 @available(*, unavailable)

--- a/Sources/AsyncAlgorithms/AsyncBufferedByteIterator.swift
+++ b/Sources/AsyncAlgorithms/AsyncBufferedByteIterator.swift
@@ -39,6 +39,7 @@
 ///     }
 ///
 ///
+@available(AsyncAlgorithms 1.0, *)
 public struct AsyncBufferedByteIterator: AsyncIteratorProtocol {
   public typealias Element = UInt8
   @usableFromInline var buffer: _AsyncBytesBuffer
@@ -67,6 +68,7 @@ public struct AsyncBufferedByteIterator: AsyncIteratorProtocol {
 @available(*, unavailable)
 extension AsyncBufferedByteIterator: Sendable {}
 
+@available(AsyncAlgorithms 1.0, *)
 @frozen @usableFromInline
 internal struct _AsyncBytesBuffer {
   @usableFromInline

--- a/Sources/AsyncAlgorithms/AsyncChain2Sequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncChain2Sequence.swift
@@ -17,6 +17,7 @@
 ///   - s2: The second asynchronous sequence.
 /// - Returns: An asynchronous sequence that iterates first over the elements of `s1`, and
 ///   then over the elements of `s2`.
+@available(AsyncAlgorithms 1.0, *)
 @inlinable
 public func chain<Base1: AsyncSequence, Base2: AsyncSequence>(
   _ s1: Base1,
@@ -26,6 +27,7 @@ public func chain<Base1: AsyncSequence, Base2: AsyncSequence>(
 }
 
 /// A concatenation of two asynchronous sequences with the same element type.
+@available(AsyncAlgorithms 1.0, *)
 @frozen
 public struct AsyncChain2Sequence<Base1: AsyncSequence, Base2: AsyncSequence> where Base1.Element == Base2.Element {
   @usableFromInline
@@ -41,10 +43,12 @@ public struct AsyncChain2Sequence<Base1: AsyncSequence, Base2: AsyncSequence> wh
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncChain2Sequence: AsyncSequence {
   public typealias Element = Base1.Element
 
   /// The iterator for a `AsyncChain2Sequence` instance.
+  @available(AsyncAlgorithms 1.0, *)
   @frozen
   public struct Iterator: AsyncIteratorProtocol {
     @usableFromInline
@@ -76,12 +80,14 @@ extension AsyncChain2Sequence: AsyncSequence {
     }
   }
 
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func makeAsyncIterator() -> Iterator {
     Iterator(base1.makeAsyncIterator(), base2.makeAsyncIterator())
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncChain2Sequence: Sendable where Base1: Sendable, Base2: Sendable {}
 
 @available(*, unavailable)

--- a/Sources/AsyncAlgorithms/AsyncChain3Sequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncChain3Sequence.swift
@@ -18,6 +18,7 @@
 ///   - s3: The third asynchronous sequence.
 /// - Returns: An asynchronous sequence that iterates first over the elements of `s1`, and
 ///   then over the elements of `s2`, and then over the elements of `s3`
+@available(AsyncAlgorithms 1.0, *)
 @inlinable
 public func chain<Base1: AsyncSequence, Base2: AsyncSequence, Base3: AsyncSequence>(
   _ s1: Base1,
@@ -28,6 +29,7 @@ public func chain<Base1: AsyncSequence, Base2: AsyncSequence, Base3: AsyncSequen
 }
 
 /// A concatenation of three asynchronous sequences with the same element type.
+@available(AsyncAlgorithms 1.0, *)
 @frozen
 public struct AsyncChain3Sequence<Base1: AsyncSequence, Base2: AsyncSequence, Base3: AsyncSequence>
 where Base1.Element == Base2.Element, Base1.Element == Base3.Element {
@@ -48,10 +50,12 @@ where Base1.Element == Base2.Element, Base1.Element == Base3.Element {
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncChain3Sequence: AsyncSequence {
   public typealias Element = Base1.Element
 
   /// The iterator for a `AsyncChain3Sequence` instance.
+  @available(AsyncAlgorithms 1.0, *)
   @frozen
   public struct Iterator: AsyncIteratorProtocol {
     @usableFromInline
@@ -93,12 +97,14 @@ extension AsyncChain3Sequence: AsyncSequence {
     }
   }
 
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func makeAsyncIterator() -> Iterator {
     Iterator(base1.makeAsyncIterator(), base2.makeAsyncIterator(), base3.makeAsyncIterator())
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncChain3Sequence: Sendable where Base1: Sendable, Base2: Sendable, Base3: Sendable {}
 
 @available(*, unavailable)

--- a/Sources/AsyncAlgorithms/AsyncChunkedByGroupSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncChunkedByGroupSequence.swift
@@ -9,9 +9,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSequence {
   /// Creates an asynchronous sequence that creates chunks of a given `RangeReplaceableCollection`
   /// type by testing if elements belong in the same group.
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func chunked<Collected: RangeReplaceableCollection>(
     into: Collected.Type,
@@ -21,6 +23,7 @@ extension AsyncSequence {
   }
 
   /// Creates an asynchronous sequence that creates chunks by testing if elements belong in the same group.
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func chunked(
     by belongInSameGroup: @escaping @Sendable (Element, Element) -> Bool
@@ -51,6 +54,7 @@ extension AsyncSequence {
 ///      // [10, 20, 30]
 ///      // [10, 40, 40]
 ///      // [10, 20]
+@available(AsyncAlgorithms 1.0, *)
 public struct AsyncChunkedByGroupSequence<Base: AsyncSequence, Collected: RangeReplaceableCollection>: AsyncSequence
 where Collected.Element == Base.Element {
   public typealias Element = Collected
@@ -121,6 +125,7 @@ where Collected.Element == Base.Element {
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncChunkedByGroupSequence: Sendable where Base: Sendable, Base.Element: Sendable {}
 
 @available(*, unavailable)

--- a/Sources/AsyncAlgorithms/AsyncChunkedOnProjectionSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncChunkedOnProjectionSequence.swift
@@ -9,8 +9,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSequence {
   /// Creates an asynchronous sequence that creates chunks of a given `RangeReplaceableCollection` type on the uniqueness of a given subject.
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func chunked<Subject: Equatable, Collected: RangeReplaceableCollection>(
     into: Collected.Type,
@@ -20,6 +22,7 @@ extension AsyncSequence {
   }
 
   /// Creates an asynchronous sequence that creates chunks on the uniqueness of a given subject.
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func chunked<Subject: Equatable>(
     on projection: @escaping @Sendable (Element) -> Subject
@@ -29,6 +32,7 @@ extension AsyncSequence {
 }
 
 /// An `AsyncSequence` that chunks on a subject when it differs from the last element.
+@available(AsyncAlgorithms 1.0, *)
 public struct AsyncChunkedOnProjectionSequence<
   Base: AsyncSequence,
   Subject: Equatable,
@@ -104,6 +108,7 @@ public struct AsyncChunkedOnProjectionSequence<
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncChunkedOnProjectionSequence: Sendable where Base: Sendable, Base.Element: Sendable {}
 
 @available(*, unavailable)

--- a/Sources/AsyncAlgorithms/AsyncChunksOfCountOrSignalSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncChunksOfCountOrSignalSequence.swift
@@ -9,8 +9,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSequence {
   /// Creates an asynchronous sequence that creates chunks of a given `RangeReplaceableCollection` type of a given count or when a signal `AsyncSequence` produces an element.
+  @available(AsyncAlgorithms 1.0, *)
   public func chunks<Signal, Collected: RangeReplaceableCollection>(
     ofCount count: Int,
     or signal: Signal,
@@ -20,6 +22,7 @@ extension AsyncSequence {
   }
 
   /// Creates an asynchronous sequence that creates chunks of a given count or when a signal `AsyncSequence` produces an element.
+  @available(AsyncAlgorithms 1.0, *)
   public func chunks<Signal>(
     ofCount count: Int,
     or signal: Signal
@@ -28,6 +31,7 @@ extension AsyncSequence {
   }
 
   /// Creates an asynchronous sequence that creates chunks of a given `RangeReplaceableCollection` type when a signal `AsyncSequence` produces an element.
+  @available(AsyncAlgorithms 1.0, *)
   public func chunked<Signal, Collected: RangeReplaceableCollection>(
     by signal: Signal,
     into: Collected.Type
@@ -36,6 +40,7 @@ extension AsyncSequence {
   }
 
   /// Creates an asynchronous sequence that creates chunks when a signal `AsyncSequence` produces an element.
+  @available(AsyncAlgorithms 1.0, *)
   public func chunked<Signal>(by signal: Signal) -> AsyncChunksOfCountOrSignalSequence<Self, [Element], Signal> {
     chunked(by: signal, into: [Element].self)
   }
@@ -78,6 +83,7 @@ extension AsyncSequence {
 }
 
 /// An `AsyncSequence` that chunks elements into collected `RangeReplaceableCollection` instances by either count or a signal from another `AsyncSequence`.
+@available(AsyncAlgorithms 1.0, *)
 public struct AsyncChunksOfCountOrSignalSequence<
   Base: AsyncSequence,
   Collected: RangeReplaceableCollection,

--- a/Sources/AsyncAlgorithms/AsyncChunksOfCountSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncChunksOfCountSequence.swift
@@ -9,8 +9,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSequence {
   /// Creates an asynchronous sequence that creates chunks of a given `RangeReplaceableCollection` of a given count.
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func chunks<Collected: RangeReplaceableCollection>(
     ofCount count: Int,
@@ -20,6 +22,7 @@ extension AsyncSequence {
   }
 
   /// Creates an asynchronous sequence that creates chunks of a given count.
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func chunks(ofCount count: Int) -> AsyncChunksOfCountSequence<Self, [Element]> {
     chunks(ofCount: count, into: [Element].self)
@@ -27,6 +30,7 @@ extension AsyncSequence {
 }
 
 /// An `AsyncSequence` that chunks elements into `RangeReplaceableCollection` instances of at least a given count.
+@available(AsyncAlgorithms 1.0, *)
 public struct AsyncChunksOfCountSequence<Base: AsyncSequence, Collected: RangeReplaceableCollection>: AsyncSequence
 where Collected.Element == Base.Element {
   public typealias Element = Collected
@@ -89,8 +93,7 @@ where Collected.Element == Base.Element {
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncChunksOfCountSequence: Sendable where Base: Sendable, Base.Element: Sendable {}
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncChunksOfCountSequence.Iterator: Sendable where Base.AsyncIterator: Sendable, Base.Element: Sendable {}
-
-@available(*, unavailable)
-extension AsyncChunksOfCountSequence.Iterator: Sendable {}

--- a/Sources/AsyncAlgorithms/AsyncCompactedSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncCompactedSequence.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSequence {
   /// Returns a new `AsyncSequence` that iterates over every non-nil element from the
   /// original `AsyncSequence`.
@@ -18,6 +19,7 @@ extension AsyncSequence {
   /// - Returns: An `AsyncSequence` where the element is the unwrapped original
   ///   element and iterates over every non-nil element from the original
   ///   `AsyncSequence`.
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func compacted<Unwrapped>() -> AsyncCompactedSequence<Self, Unwrapped>
   where Element == Unwrapped? {
@@ -27,6 +29,7 @@ extension AsyncSequence {
 
 /// An `AsyncSequence` that iterates over every non-nil element from the original
 /// `AsyncSequence`.
+@available(AsyncAlgorithms 1.0, *)
 @frozen
 public struct AsyncCompactedSequence<Base: AsyncSequence, Element>: AsyncSequence
 where Base.Element == Element? {
@@ -66,6 +69,7 @@ where Base.Element == Element? {
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncCompactedSequence: Sendable where Base: Sendable, Base.Element: Sendable {}
 
 @available(*, unavailable)

--- a/Sources/AsyncAlgorithms/AsyncExclusiveReductionsSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncExclusiveReductionsSequence.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSequence {
   /// Returns an asynchronous sequence containing the accumulated results of combining the
   /// elements of the asynchronous sequence using the given closure.
@@ -22,6 +23,7 @@ extension AsyncSequence {
   ///     the next element in the receiving asynchronous sequence, which it returns.
   /// - Returns: An asynchronous sequence of the initial value followed by the reduced
   ///   elements.
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func reductions<Result>(
     _ initial: Result,
@@ -45,6 +47,7 @@ extension AsyncSequence {
   ///     previous result instead of returning a value.
   /// - Returns: An asynchronous sequence of the initial value followed by the reduced
   ///   elements.
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func reductions<Result>(
     into initial: Result,
@@ -56,6 +59,7 @@ extension AsyncSequence {
 
 /// An asynchronous sequence of applying a transform to the element of an asynchronous sequence and the
 /// previously transformed result.
+@available(AsyncAlgorithms 1.0, *)
 @frozen
 public struct AsyncExclusiveReductionsSequence<Base: AsyncSequence, Element> {
   @usableFromInline
@@ -75,8 +79,10 @@ public struct AsyncExclusiveReductionsSequence<Base: AsyncSequence, Element> {
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncExclusiveReductionsSequence: AsyncSequence {
   /// The iterator for an `AsyncExclusiveReductionsSequence` instance.
+  @available(AsyncAlgorithms 1.0, *)
   @frozen
   public struct Iterator: AsyncIteratorProtocol {
     @usableFromInline
@@ -113,12 +119,14 @@ extension AsyncExclusiveReductionsSequence: AsyncSequence {
     }
   }
 
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func makeAsyncIterator() -> Iterator {
     Iterator(base.makeAsyncIterator(), initial: initial, transform: transform)
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncExclusiveReductionsSequence: Sendable where Base: Sendable, Element: Sendable {}
 
 @available(*, unavailable)

--- a/Sources/AsyncAlgorithms/AsyncInclusiveReductionsSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncInclusiveReductionsSequence.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSequence {
   /// Returns an asynchronous sequence containing the accumulated results of combining the
   /// elements of the asynchronous sequence using the given closure.
@@ -28,6 +29,7 @@ extension AsyncSequence {
   ///   result and the next element in the receiving sequence, and returns
   ///   the result.
   /// - Returns: An asynchronous sequence of the reduced elements.
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func reductions(
     _ transform: @Sendable @escaping (Element, Element) async -> Element
@@ -38,6 +40,7 @@ extension AsyncSequence {
 
 /// An asynchronous sequence containing the accumulated results of combining the
 /// elements of the asynchronous sequence using a given closure.
+@available(AsyncAlgorithms 1.0, *)
 @frozen
 public struct AsyncInclusiveReductionsSequence<Base: AsyncSequence> {
   @usableFromInline
@@ -53,10 +56,12 @@ public struct AsyncInclusiveReductionsSequence<Base: AsyncSequence> {
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncInclusiveReductionsSequence: AsyncSequence {
   public typealias Element = Base.Element
 
   /// The iterator for an `AsyncInclusiveReductionsSequence` instance.
+  @available(AsyncAlgorithms 1.0, *)
   @frozen
   public struct Iterator: AsyncIteratorProtocol {
     @usableFromInline
@@ -89,12 +94,14 @@ extension AsyncInclusiveReductionsSequence: AsyncSequence {
     }
   }
 
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func makeAsyncIterator() -> Iterator {
     Iterator(base.makeAsyncIterator(), transform: transform)
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncInclusiveReductionsSequence: Sendable where Base: Sendable {}
 
 @available(*, unavailable)

--- a/Sources/AsyncAlgorithms/AsyncJoinedBySeparatorSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncJoinedBySeparatorSequence.swift
@@ -9,8 +9,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSequence where Element: AsyncSequence {
   /// Concatenate an `AsyncSequence` of `AsyncSequence` elements with a separator.
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func joined<Separator: AsyncSequence>(
     separator: Separator
@@ -20,6 +22,7 @@ extension AsyncSequence where Element: AsyncSequence {
 }
 
 /// An `AsyncSequence` that concatenates `AsyncSequence` elements with a separator.
+@available(AsyncAlgorithms 1.0, *)
 public struct AsyncJoinedBySeparatorSequence<Base: AsyncSequence, Separator: AsyncSequence>: AsyncSequence
 where Base.Element: AsyncSequence, Separator.Element == Base.Element.Element {
   public typealias Element = Base.Element.Element
@@ -143,6 +146,7 @@ where Base.Element: AsyncSequence, Separator.Element == Base.Element.Element {
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncJoinedBySeparatorSequence: Sendable
 where Base: Sendable, Base.Element: Sendable, Base.Element.Element: Sendable, Separator: Sendable {}
 

--- a/Sources/AsyncAlgorithms/AsyncJoinedSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncJoinedSequence.swift
@@ -9,8 +9,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSequence where Element: AsyncSequence {
   /// Concatenate an `AsyncSequence` of `AsyncSequence` elements
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func joined() -> AsyncJoinedSequence<Self> {
     return AsyncJoinedSequence(self)
@@ -18,6 +20,7 @@ extension AsyncSequence where Element: AsyncSequence {
 }
 
 /// An `AsyncSequence` that concatenates`AsyncSequence` elements
+@available(AsyncAlgorithms 1.0, *)
 @frozen
 public struct AsyncJoinedSequence<Base: AsyncSequence>: AsyncSequence where Base.Element: AsyncSequence {
   public typealias Element = Base.Element.Element
@@ -90,6 +93,7 @@ public struct AsyncJoinedSequence<Base: AsyncSequence>: AsyncSequence where Base
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncJoinedSequence: Sendable
 where Base: Sendable, Base.Element: Sendable, Base.Element.Element: Sendable {}
 

--- a/Sources/AsyncAlgorithms/AsyncRemoveDuplicatesSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncRemoveDuplicatesSequence.swift
@@ -9,8 +9,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSequence where Element: Equatable {
   /// Creates an asynchronous sequence that omits repeated elements.
+  @available(AsyncAlgorithms 1.0, *)
   public func removeDuplicates() -> AsyncRemoveDuplicatesSequence<Self> {
     AsyncRemoveDuplicatesSequence(self) { lhs, rhs in
       lhs == rhs
@@ -18,8 +20,10 @@ extension AsyncSequence where Element: Equatable {
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSequence {
   /// Creates an asynchronous sequence that omits repeated elements by testing them with a predicate.
+  @available(AsyncAlgorithms 1.0, *)
   public func removeDuplicates(
     by predicate: @escaping @Sendable (Element, Element) async -> Bool
   ) -> AsyncRemoveDuplicatesSequence<Self> {
@@ -27,6 +31,7 @@ extension AsyncSequence {
   }
 
   /// Creates an asynchronous sequence that omits repeated elements by testing them with an error-throwing predicate.
+  @available(AsyncAlgorithms 1.0, *)
   public func removeDuplicates(
     by predicate: @escaping @Sendable (Element, Element) async throws -> Bool
   ) -> AsyncThrowingRemoveDuplicatesSequence<Self> {
@@ -35,6 +40,7 @@ extension AsyncSequence {
 }
 
 /// An asynchronous sequence that omits repeated elements by testing them with a predicate.
+@available(AsyncAlgorithms 1.0, *)
 public struct AsyncRemoveDuplicatesSequence<Base: AsyncSequence>: AsyncSequence {
   public typealias Element = Base.Element
 
@@ -90,6 +96,7 @@ public struct AsyncRemoveDuplicatesSequence<Base: AsyncSequence>: AsyncSequence 
 }
 
 /// An asynchronous sequence that omits repeated elements by testing them with an error-throwing predicate.
+@available(AsyncAlgorithms 1.0, *)
 public struct AsyncThrowingRemoveDuplicatesSequence<Base: AsyncSequence>: AsyncSequence {
   public typealias Element = Base.Element
 
@@ -144,7 +151,9 @@ public struct AsyncThrowingRemoveDuplicatesSequence<Base: AsyncSequence>: AsyncS
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncRemoveDuplicatesSequence: Sendable where Base: Sendable, Base.Element: Sendable {}
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncThrowingRemoveDuplicatesSequence: Sendable where Base: Sendable, Base.Element: Sendable {}
 
 @available(*, unavailable)

--- a/Sources/AsyncAlgorithms/AsyncSyncSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncSyncSequence.swift
@@ -9,10 +9,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 extension Sequence {
   /// An asynchronous sequence containing the same elements as this sequence,
   /// but on which operations, such as `map` and `filter`, are
   /// implemented asynchronously.
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public var async: AsyncSyncSequence<Self> {
     AsyncSyncSequence(self)
@@ -27,6 +29,7 @@ extension Sequence {
 ///
 /// This functions similarly to `LazySequence` by accessing elements sequentially
 /// in the iterator's `next()` method.
+@available(AsyncAlgorithms 1.0, *)
 @frozen
 public struct AsyncSyncSequence<Base: Sequence>: AsyncSequence {
   public typealias Element = Base.Element
@@ -65,6 +68,7 @@ public struct AsyncSyncSequence<Base: Sequence>: AsyncSequence {
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSyncSequence: Sendable where Base: Sendable {}
 
 @available(*, unavailable)

--- a/Sources/AsyncAlgorithms/AsyncThrottleSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncThrottleSequence.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSequence {
   /// Create a rate-limited `AsyncSequence` by emitting values at most every specified interval.
   @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)

--- a/Sources/AsyncAlgorithms/AsyncThrowingExclusiveReductionsSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncThrowingExclusiveReductionsSequence.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSequence {
   /// Returns an asynchronous sequence containing the accumulated results of combining the
   /// elements of the asynchronous sequence using the given error-throwing closure.
@@ -23,6 +24,7 @@ extension AsyncSequence {
   ///     the result. If the closure throws an error, the sequence throws.
   /// - Returns: An asynchronous sequence of the initial value followed by the reduced
   ///   elements.
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func reductions<Result>(
     _ initial: Result,
@@ -47,6 +49,7 @@ extension AsyncSequence {
   ///     error, the sequence throws.
   /// - Returns: An asynchronous sequence of the initial value followed by the reduced
   ///   elements.
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func reductions<Result>(
     into initial: Result,
@@ -58,6 +61,7 @@ extension AsyncSequence {
 
 /// An asynchronous sequence of applying an error-throwing transform to the element of
 /// an asynchronous sequence and the previously transformed result.
+@available(AsyncAlgorithms 1.0, *)
 @frozen
 public struct AsyncThrowingExclusiveReductionsSequence<Base: AsyncSequence, Element> {
   @usableFromInline
@@ -81,8 +85,10 @@ public struct AsyncThrowingExclusiveReductionsSequence<Base: AsyncSequence, Elem
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncThrowingExclusiveReductionsSequence: AsyncSequence {
   /// The iterator for an `AsyncThrowingExclusiveReductionsSequence` instance.
+  @available(AsyncAlgorithms 1.0, *)
   @frozen
   public struct Iterator: AsyncIteratorProtocol {
     @usableFromInline
@@ -124,12 +130,14 @@ extension AsyncThrowingExclusiveReductionsSequence: AsyncSequence {
     }
   }
 
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func makeAsyncIterator() -> Iterator {
     Iterator(base.makeAsyncIterator(), initial: initial, transform: transform)
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncThrowingExclusiveReductionsSequence: Sendable where Base: Sendable, Element: Sendable {}
 
 @available(*, unavailable)

--- a/Sources/AsyncAlgorithms/AsyncThrowingInclusiveReductionsSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncThrowingInclusiveReductionsSequence.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSequence {
   /// Returns an asynchronous sequence containing the accumulated results of combining the
   /// elements of the asynchronous sequence using the given error-throwing closure.
@@ -27,6 +28,7 @@ extension AsyncSequence {
   ///   result and the next element in the receiving sequence. If the closure
   ///     throws an error, the sequence throws.
   /// - Returns: An asynchronous sequence of the reduced elements.
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func reductions(
     _ transform: @Sendable @escaping (Element, Element) async throws -> Element
@@ -37,6 +39,7 @@ extension AsyncSequence {
 
 /// An asynchronous sequence containing the accumulated results of combining the
 /// elements of the asynchronous sequence using a given error-throwing closure.
+@available(AsyncAlgorithms 1.0, *)
 @frozen
 public struct AsyncThrowingInclusiveReductionsSequence<Base: AsyncSequence> {
   @usableFromInline
@@ -52,10 +55,12 @@ public struct AsyncThrowingInclusiveReductionsSequence<Base: AsyncSequence> {
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncThrowingInclusiveReductionsSequence: AsyncSequence {
   public typealias Element = Base.Element
 
   /// The iterator for an `AsyncThrowingInclusiveReductionsSequence` instance.
+  @available(AsyncAlgorithms 1.0, *)
   @frozen
   public struct Iterator: AsyncIteratorProtocol {
     @usableFromInline
@@ -93,12 +98,14 @@ extension AsyncThrowingInclusiveReductionsSequence: AsyncSequence {
     }
   }
 
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func makeAsyncIterator() -> Iterator {
     Iterator(base.makeAsyncIterator(), transform: transform)
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncThrowingInclusiveReductionsSequence: Sendable where Base: Sendable {}
 
 @available(*, unavailable)

--- a/Sources/AsyncAlgorithms/Buffer/AsyncBufferSequence.swift
+++ b/Sources/AsyncAlgorithms/Buffer/AsyncBufferSequence.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSequence where Self: Sendable {
   /// Creates an asynchronous sequence that buffers elements.
   ///
@@ -20,6 +21,7 @@ extension AsyncSequence where Self: Sendable {
   ///
   /// - Parameter policy: A policy that drives the behaviour of the ``AsyncBufferSequence``
   /// - Returns: An asynchronous sequence that buffers elements up to a given limit.
+  @available(AsyncAlgorithms 1.0, *)
   public func buffer(
     policy: AsyncBufferSequencePolicy
   ) -> AsyncBufferSequence<Self> {
@@ -28,6 +30,7 @@ extension AsyncSequence where Self: Sendable {
 }
 
 /// A policy dictating the buffering behaviour of an ``AsyncBufferSequence``
+@available(AsyncAlgorithms 1.0, *)
 public struct AsyncBufferSequencePolicy: Sendable {
   enum _Policy {
     case bounded(Int)
@@ -69,6 +72,7 @@ public struct AsyncBufferSequencePolicy: Sendable {
 }
 
 /// An `AsyncSequence` that buffers elements in regard to a policy.
+@available(AsyncAlgorithms 1.0, *)
 public struct AsyncBufferSequence<Base: AsyncSequence & Sendable>: AsyncSequence {
   enum StorageType {
     case transparent(Base.AsyncIterator)
@@ -125,6 +129,7 @@ public struct AsyncBufferSequence<Base: AsyncSequence & Sendable>: AsyncSequence
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncBufferSequence: Sendable where Base: Sendable {}
 
 @available(*, unavailable)

--- a/Sources/AsyncAlgorithms/Buffer/BoundedBufferStateMachine.swift
+++ b/Sources/AsyncAlgorithms/Buffer/BoundedBufferStateMachine.swift
@@ -11,6 +11,7 @@
 
 import DequeModule
 
+@available(AsyncAlgorithms 1.0, *)
 struct BoundedBufferStateMachine<Base: AsyncSequence> {
   typealias Element = Base.Element
   typealias SuspendedProducer = UnsafeContinuation<Void, Never>
@@ -322,5 +323,7 @@ struct BoundedBufferStateMachine<Base: AsyncSequence> {
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension BoundedBufferStateMachine: Sendable where Base: Sendable {}
+@available(AsyncAlgorithms 1.0, *)
 extension BoundedBufferStateMachine.State: Sendable where Base: Sendable {}

--- a/Sources/AsyncAlgorithms/Buffer/BoundedBufferStorage.swift
+++ b/Sources/AsyncAlgorithms/Buffer/BoundedBufferStorage.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 final class BoundedBufferStorage<Base: AsyncSequence>: Sendable where Base: Sendable {
   private let stateMachine: ManagedCriticalState<BoundedBufferStateMachine<Base>>
 

--- a/Sources/AsyncAlgorithms/Buffer/UnboundedBufferStateMachine.swift
+++ b/Sources/AsyncAlgorithms/Buffer/UnboundedBufferStateMachine.swift
@@ -11,6 +11,7 @@
 
 import DequeModule
 
+@available(AsyncAlgorithms 1.0, *)
 struct UnboundedBufferStateMachine<Base: AsyncSequence> {
   typealias Element = Base.Element
   typealias SuspendedConsumer = UnsafeContinuation<Result<Element, Error>?, Never>
@@ -252,5 +253,7 @@ struct UnboundedBufferStateMachine<Base: AsyncSequence> {
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension UnboundedBufferStateMachine: Sendable where Base: Sendable {}
+@available(AsyncAlgorithms 1.0, *)
 extension UnboundedBufferStateMachine.State: Sendable where Base: Sendable {}

--- a/Sources/AsyncAlgorithms/Buffer/UnboundedBufferStorage.swift
+++ b/Sources/AsyncAlgorithms/Buffer/UnboundedBufferStorage.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 final class UnboundedBufferStorage<Base: AsyncSequence>: Sendable where Base: Sendable {
   private let stateMachine: ManagedCriticalState<UnboundedBufferStateMachine<Base>>
 

--- a/Sources/AsyncAlgorithms/Channels/AsyncChannel.swift
+++ b/Sources/AsyncAlgorithms/Channels/AsyncChannel.swift
@@ -19,6 +19,7 @@
 /// on the `Iterator` is made, or when `finish()` is called from another Task.
 /// As `finish()` induces a terminal state, there is no more need for a back pressure management.
 /// This function does not suspend and will finish all the pending iterations.
+@available(AsyncAlgorithms 1.0, *)
 public final class AsyncChannel<Element: Sendable>: AsyncSequence, Sendable {
   public typealias Element = Element
   public typealias AsyncIterator = Iterator

--- a/Sources/AsyncAlgorithms/Channels/AsyncThrowingChannel.swift
+++ b/Sources/AsyncAlgorithms/Channels/AsyncThrowingChannel.swift
@@ -18,6 +18,7 @@
 /// and is resumed when the next call to `next()` on the `Iterator` is made, or when `finish()`/`fail(_:)` is called
 /// from another Task. As `finish()` and `fail(_:)` induce a terminal state, there is no more need for a back pressure management.
 /// Those functions do not suspend and will finish all the pending iterations.
+@available(AsyncAlgorithms 1.0, *)
 public final class AsyncThrowingChannel<Element: Sendable, Failure: Error>: AsyncSequence, Sendable {
   public typealias Element = Element
   public typealias AsyncIterator = Iterator

--- a/Sources/AsyncAlgorithms/Channels/ChannelStateMachine.swift
+++ b/Sources/AsyncAlgorithms/Channels/ChannelStateMachine.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 import OrderedCollections
 
+@available(AsyncAlgorithms 1.0, *)
 struct ChannelStateMachine<Element: Sendable, Failure: Error>: Sendable {
   private struct SuspendedProducer: Hashable, Sendable {
     let id: UInt64

--- a/Sources/AsyncAlgorithms/Channels/ChannelStorage.swift
+++ b/Sources/AsyncAlgorithms/Channels/ChannelStorage.swift
@@ -8,6 +8,7 @@
 // See https://swift.org/LICENSE.txt for license information
 //
 //===----------------------------------------------------------------------===//
+@available(AsyncAlgorithms 1.0, *)
 struct ChannelStorage<Element: Sendable, Failure: Error>: Sendable {
   private let stateMachine: ManagedCriticalState<ChannelStateMachine<Element, Failure>>
   private let ids = ManagedCriticalState<UInt64>(0)

--- a/Sources/AsyncAlgorithms/CombineLatest/AsyncCombineLatest2Sequence.swift
+++ b/Sources/AsyncAlgorithms/CombineLatest/AsyncCombineLatest2Sequence.swift
@@ -20,6 +20,7 @@
 /// Throws:
 /// ``combineLatest(_:_:)`` throws when one of the bases throws. If one of the bases threw any buffered and not yet consumed
 /// values will be dropped.
+@available(AsyncAlgorithms 1.0, *)
 public func combineLatest<
   Base1: AsyncSequence,
   Base2: AsyncSequence
@@ -34,6 +35,7 @@ where
 }
 
 /// An `AsyncSequence` that combines the latest values produced from two asynchronous sequences into an asynchronous sequence of tuples.
+@available(AsyncAlgorithms 1.0, *)
 public struct AsyncCombineLatest2Sequence<
   Base1: AsyncSequence,
   Base2: AsyncSequence

--- a/Sources/AsyncAlgorithms/CombineLatest/AsyncCombineLatest3Sequence.swift
+++ b/Sources/AsyncAlgorithms/CombineLatest/AsyncCombineLatest3Sequence.swift
@@ -20,6 +20,7 @@
 /// Throws:
 /// ``combineLatest(_:_:_:)`` throws when one of the bases throws. If one of the bases threw any buffered and not yet consumed
 /// values will be dropped.
+@available(AsyncAlgorithms 1.0, *)
 public func combineLatest<
   Base1: AsyncSequence,
   Base2: AsyncSequence,
@@ -37,6 +38,7 @@ where
 }
 
 /// An `AsyncSequence` that combines the latest values produced from three asynchronous sequences into an asynchronous sequence of tuples.
+@available(AsyncAlgorithms 1.0, *)
 public struct AsyncCombineLatest3Sequence<
   Base1: AsyncSequence,
   Base2: AsyncSequence,

--- a/Sources/AsyncAlgorithms/CombineLatest/CombineLatestStateMachine.swift
+++ b/Sources/AsyncAlgorithms/CombineLatest/CombineLatestStateMachine.swift
@@ -12,6 +12,7 @@
 import DequeModule
 
 /// State machine for combine latest
+@available(AsyncAlgorithms 1.0, *)
 struct CombineLatestStateMachine<
   Base1: AsyncSequence,
   Base2: AsyncSequence,

--- a/Sources/AsyncAlgorithms/CombineLatest/CombineLatestStorage.swift
+++ b/Sources/AsyncAlgorithms/CombineLatest/CombineLatestStorage.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 final class CombineLatestStorage<
   Base1: AsyncSequence,
   Base2: AsyncSequence,

--- a/Sources/AsyncAlgorithms/Debounce/AsyncDebounceSequence.swift
+++ b/Sources/AsyncAlgorithms/Debounce/AsyncDebounceSequence.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSequence {
   /// Creates an asynchronous sequence that emits the latest element after a given quiescence period
   /// has elapsed by using a specified Clock.

--- a/Sources/AsyncAlgorithms/Dictionary.swift
+++ b/Sources/AsyncAlgorithms/Dictionary.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 extension Dictionary {
   /// Creates a new dictionary from the key-value pairs in the given asynchronous sequence.
   ///
@@ -21,6 +22,7 @@ extension Dictionary {
   /// - Parameter keysAndValues: An asynchronous sequence of key-value pairs to use for
   ///   the new dictionary. Every key in `keysAndValues` must be unique.
   /// - Precondition: The sequence must not have duplicate keys.
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public init<S: AsyncSequence>(uniqueKeysWithValues keysAndValues: S) async rethrows
   where S.Element == (Key, Value) {
@@ -45,6 +47,7 @@ extension Dictionary {
   ///     keys that are encountered. The closure returns the desired value for
   ///     the final dictionary, or throws an error if building the dictionary
   ///     can't proceed.
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public init<S: AsyncSequence>(
     _ keysAndValues: S,
@@ -72,6 +75,7 @@ extension Dictionary {
   ///   - values: An asynchronous sequence of values to group into a dictionary.
   ///   - keyForValue: A closure that returns a key for each element in
   ///     `values`.
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public init<S: AsyncSequence>(grouping values: S, by keyForValue: (S.Element) async throws -> Key) async rethrows
   where Value == [S.Element] {

--- a/Sources/AsyncAlgorithms/Interspersed/AsyncInterspersedSequence.swift
+++ b/Sources/AsyncAlgorithms/Interspersed/AsyncInterspersedSequence.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSequence {
   /// Returns a new asynchronous sequence containing the elements of this asynchronous sequence, inserting
   /// the given separator between each element.
@@ -30,6 +31,7 @@ extension AsyncSequence {
   ///   - every: Dictates after how many elements a separator should be inserted.
   ///   - separator: The value to insert in between each of this async sequence’s elements.
   /// - Returns: The interspersed asynchronous sequence of elements.
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func interspersed(every: Int = 1, with separator: Element) -> AsyncInterspersedSequence<Self> {
     AsyncInterspersedSequence(self, every: every, separator: separator)
@@ -55,6 +57,7 @@ extension AsyncSequence {
   ///   - every: Dictates after how many elements a separator should be inserted.
   ///   - separator: A closure that produces the value to insert in between each of this async sequence’s elements.
   /// - Returns: The interspersed asynchronous sequence of elements.
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func interspersed(
     every: Int = 1,
@@ -83,6 +86,7 @@ extension AsyncSequence {
   ///   - every: Dictates after how many elements a separator should be inserted.
   ///   - separator: A closure that produces the value to insert in between each of this async sequence’s elements.
   /// - Returns: The interspersed asynchronous sequence of elements.
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func interspersed(
     every: Int = 1,
@@ -111,6 +115,7 @@ extension AsyncSequence {
   ///   - every: Dictates after how many elements a separator should be inserted.
   ///   - separator: A closure that produces the value to insert in between each of this async sequence’s elements.
   /// - Returns: The interspersed asynchronous sequence of elements.
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func interspersed(
     every: Int = 1,
@@ -139,6 +144,7 @@ extension AsyncSequence {
   ///   - every: Dictates after how many elements a separator should be inserted.
   ///   - separator: A closure that produces the value to insert in between each of this async sequence’s elements.
   /// - Returns: The interspersed asynchronous sequence of elements.
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func interspersed(
     every: Int = 1,
@@ -150,6 +156,7 @@ extension AsyncSequence {
 
 /// An asynchronous sequence that presents the elements of a base asynchronous sequence of
 /// elements with a separator between each of those elements.
+@available(AsyncAlgorithms 1.0, *)
 public struct AsyncInterspersedSequence<Base: AsyncSequence> {
   @usableFromInline
   internal enum Separator {
@@ -192,10 +199,12 @@ public struct AsyncInterspersedSequence<Base: AsyncSequence> {
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncInterspersedSequence: AsyncSequence {
   public typealias Element = Base.Element
 
   /// The iterator for an `AsyncInterspersedSequence` asynchronous sequence.
+  @available(AsyncAlgorithms 1.0, *)
   public struct Iterator: AsyncIteratorProtocol {
     @usableFromInline
     internal enum State {
@@ -293,6 +302,7 @@ extension AsyncInterspersedSequence: AsyncSequence {
     }
   }
 
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func makeAsyncIterator() -> Iterator {
     Iterator(self.base.makeAsyncIterator(), every: self.every, separator: self.separator)
@@ -301,6 +311,7 @@ extension AsyncInterspersedSequence: AsyncSequence {
 
 /// An asynchronous sequence that presents the elements of a base asynchronous sequence of
 /// elements with a separator between each of those elements.
+@available(AsyncAlgorithms 1.0, *)
 public struct AsyncThrowingInterspersedSequence<Base: AsyncSequence> {
   @usableFromInline
   internal enum Separator {
@@ -334,10 +345,12 @@ public struct AsyncThrowingInterspersedSequence<Base: AsyncSequence> {
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncThrowingInterspersedSequence: AsyncSequence {
   public typealias Element = Base.Element
 
   /// The iterator for an `AsyncInterspersedSequence` asynchronous sequence.
+  @available(AsyncAlgorithms 1.0, *)
   public struct Iterator: AsyncIteratorProtocol {
     @usableFromInline
     internal enum State {
@@ -432,16 +445,21 @@ extension AsyncThrowingInterspersedSequence: AsyncSequence {
     }
   }
 
+  @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func makeAsyncIterator() -> Iterator {
     Iterator(self.base.makeAsyncIterator(), every: self.every, separator: self.separator)
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncInterspersedSequence: Sendable where Base: Sendable, Base.Element: Sendable {}
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncInterspersedSequence.Separator: Sendable where Base: Sendable, Base.Element: Sendable {}
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncThrowingInterspersedSequence: Sendable where Base: Sendable, Base.Element: Sendable {}
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncThrowingInterspersedSequence.Separator: Sendable where Base: Sendable, Base.Element: Sendable {}
 
 @available(*, unavailable)

--- a/Sources/AsyncAlgorithms/Merge/AsyncMerge2Sequence.swift
+++ b/Sources/AsyncAlgorithms/Merge/AsyncMerge2Sequence.swift
@@ -12,6 +12,7 @@
 import DequeModule
 
 /// Creates an asynchronous sequence of elements from two underlying asynchronous sequences
+@available(AsyncAlgorithms 1.0, *)
 public func merge<Base1: AsyncSequence, Base2: AsyncSequence>(
   _ base1: Base1,
   _ base2: Base2
@@ -26,6 +27,7 @@ where
 }
 
 /// An `AsyncSequence` that takes two upstream `AsyncSequence`s and combines their elements.
+@available(AsyncAlgorithms 1.0, *)
 public struct AsyncMerge2Sequence<
   Base1: AsyncSequence,
   Base2: AsyncSequence
@@ -55,7 +57,9 @@ where
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncMerge2Sequence: AsyncSequence {
+  @available(AsyncAlgorithms 1.0, *)
   public func makeAsyncIterator() -> Iterator {
     let storage = MergeStorage<Base1, Base2, Base1>(
       base1: base1,
@@ -66,7 +70,9 @@ extension AsyncMerge2Sequence: AsyncSequence {
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncMerge2Sequence {
+  @available(AsyncAlgorithms 1.0, *)
   public struct Iterator: AsyncIteratorProtocol {
     /// This class is needed to hook the deinit to observe once all references to the ``AsyncIterator`` are dropped.
     ///

--- a/Sources/AsyncAlgorithms/Merge/AsyncMerge3Sequence.swift
+++ b/Sources/AsyncAlgorithms/Merge/AsyncMerge3Sequence.swift
@@ -12,6 +12,7 @@
 import DequeModule
 
 /// Creates an asynchronous sequence of elements from two underlying asynchronous sequences
+@available(AsyncAlgorithms 1.0, *)
 public func merge<
   Base1: AsyncSequence,
   Base2: AsyncSequence,
@@ -29,6 +30,7 @@ where
 }
 
 /// An `AsyncSequence` that takes three upstream `AsyncSequence`s and combines their elements.
+@available(AsyncAlgorithms 1.0, *)
 public struct AsyncMerge3Sequence<
   Base1: AsyncSequence,
   Base2: AsyncSequence,
@@ -65,7 +67,9 @@ where
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncMerge3Sequence: AsyncSequence {
+  @available(AsyncAlgorithms 1.0, *)
   public func makeAsyncIterator() -> Iterator {
     let storage = MergeStorage(
       base1: base1,
@@ -76,7 +80,9 @@ extension AsyncMerge3Sequence: AsyncSequence {
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncMerge3Sequence {
+  @available(AsyncAlgorithms 1.0, *)
   public struct Iterator: AsyncIteratorProtocol {
     /// This class is needed to hook the deinit to observe once all references to the ``AsyncIterator`` are dropped.
     ///

--- a/Sources/AsyncAlgorithms/Merge/MergeStateMachine.swift
+++ b/Sources/AsyncAlgorithms/Merge/MergeStateMachine.swift
@@ -15,6 +15,7 @@ import DequeModule
 ///
 /// Right now this state machine supports 3 upstream `AsyncSequences`; however, this can easily be extended.
 /// Once variadic generic land we should migrate this to use them instead.
+@available(AsyncAlgorithms 1.0, *)
 struct MergeStateMachine<
   Base1: AsyncSequence,
   Base2: AsyncSequence,

--- a/Sources/AsyncAlgorithms/Merge/MergeStorage.swift
+++ b/Sources/AsyncAlgorithms/Merge/MergeStorage.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 final class MergeStorage<
   Base1: AsyncSequence,
   Base2: AsyncSequence,

--- a/Sources/AsyncAlgorithms/RangeReplaceableCollection.swift
+++ b/Sources/AsyncAlgorithms/RangeReplaceableCollection.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 extension RangeReplaceableCollection {
   /// Creates a new instance of a collection containing the elements of an asynchronous sequence.
   ///

--- a/Sources/AsyncAlgorithms/SetAlgebra.swift
+++ b/Sources/AsyncAlgorithms/SetAlgebra.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 extension SetAlgebra {
   /// Creates a new set from an asynchronous sequence of items.
   ///

--- a/Sources/AsyncAlgorithms/Zip/AsyncZip2Sequence.swift
+++ b/Sources/AsyncAlgorithms/Zip/AsyncZip2Sequence.swift
@@ -11,6 +11,7 @@
 
 /// Creates an asynchronous sequence that concurrently awaits values from two `AsyncSequence` types
 /// and emits a tuple of the values.
+@available(AsyncAlgorithms 1.0, *)
 public func zip<Base1: AsyncSequence, Base2: AsyncSequence>(
   _ base1: Base1,
   _ base2: Base2
@@ -20,6 +21,7 @@ public func zip<Base1: AsyncSequence, Base2: AsyncSequence>(
 
 /// An asynchronous sequence that concurrently awaits values from two `AsyncSequence` types
 /// and emits a tuple of the values.
+@available(AsyncAlgorithms 1.0, *)
 public struct AsyncZip2Sequence<Base1: AsyncSequence, Base2: AsyncSequence>: AsyncSequence, Sendable
 where Base1: Sendable, Base1.Element: Sendable, Base2: Sendable, Base2.Element: Sendable {
   public typealias Element = (Base1.Element, Base2.Element)

--- a/Sources/AsyncAlgorithms/Zip/AsyncZip3Sequence.swift
+++ b/Sources/AsyncAlgorithms/Zip/AsyncZip3Sequence.swift
@@ -11,6 +11,7 @@
 
 /// Creates an asynchronous sequence that concurrently awaits values from three `AsyncSequence` types
 /// and emits a tuple of the values.
+@available(AsyncAlgorithms 1.0, *)
 public func zip<Base1: AsyncSequence, Base2: AsyncSequence, Base3: AsyncSequence>(
   _ base1: Base1,
   _ base2: Base2,
@@ -21,6 +22,7 @@ public func zip<Base1: AsyncSequence, Base2: AsyncSequence, Base3: AsyncSequence
 
 /// An asynchronous sequence that concurrently awaits values from three `AsyncSequence` types
 /// and emits a tuple of the values.
+@available(AsyncAlgorithms 1.0, *)
 public struct AsyncZip3Sequence<Base1: AsyncSequence, Base2: AsyncSequence, Base3: AsyncSequence>: AsyncSequence,
   Sendable
 where

--- a/Sources/AsyncAlgorithms/Zip/ZipStateMachine.swift
+++ b/Sources/AsyncAlgorithms/Zip/ZipStateMachine.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 /// State machine for zip
+@available(AsyncAlgorithms 1.0, *)
 struct ZipStateMachine<
   Base1: AsyncSequence,
   Base2: AsyncSequence,

--- a/Sources/AsyncAlgorithms/Zip/ZipStorage.swift
+++ b/Sources/AsyncAlgorithms/Zip/ZipStorage.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 final class ZipStorage<Base1: AsyncSequence, Base2: AsyncSequence, Base3: AsyncSequence>: Sendable
 where
   Base1: Sendable,

--- a/Sources/AsyncAlgorithms_XCTest/ValidationTest.swift
+++ b/Sources/AsyncAlgorithms_XCTest/ValidationTest.swift
@@ -33,6 +33,7 @@ extension XCTestCase {
     #endif
   }
 
+  @available(AsyncAlgorithms 1.0, *)
   func validate<Test: AsyncSequenceValidationTest, Theme: AsyncSequenceValidationTheme>(
     theme: Theme,
     expectedFailures: Set<String>,
@@ -77,6 +78,7 @@ extension XCTestCase {
     }
   }
 
+  @available(AsyncAlgorithms 1.0, *)
   func validate<Test: AsyncSequenceValidationTest>(
     expectedFailures: Set<String>,
     @AsyncSequenceValidationDiagram _ build: (AsyncSequenceValidationDiagram) -> Test,
@@ -86,6 +88,7 @@ extension XCTestCase {
     validate(theme: .ascii, expectedFailures: expectedFailures, build, file: file, line: line)
   }
 
+  @available(AsyncAlgorithms 1.0, *)
   public func validate<Test: AsyncSequenceValidationTest, Theme: AsyncSequenceValidationTheme>(
     theme: Theme,
     @AsyncSequenceValidationDiagram _ build: (AsyncSequenceValidationDiagram) -> Test,
@@ -95,6 +98,7 @@ extension XCTestCase {
     validate(theme: theme, expectedFailures: [], build, file: file, line: line)
   }
 
+  @available(AsyncAlgorithms 1.0, *)
   public func validate<Test: AsyncSequenceValidationTest>(
     @AsyncSequenceValidationDiagram _ build: (AsyncSequenceValidationDiagram) -> Test,
     file: StaticString = #file,

--- a/Sources/AsyncSequenceValidation/AsyncSequenceValidationDiagram.swift
+++ b/Sources/AsyncSequenceValidation/AsyncSequenceValidationDiagram.swift
@@ -12,6 +12,7 @@
 import _CAsyncSequenceValidationSupport
 
 @resultBuilder
+@available(AsyncAlgorithms 1.0, *)
 public struct AsyncSequenceValidationDiagram: Sendable {
   public struct Component<T> {
     var component: T

--- a/Sources/AsyncSequenceValidation/Clock.swift
+++ b/Sources/AsyncSequenceValidation/Clock.swift
@@ -11,6 +11,7 @@
 
 import AsyncAlgorithms
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSequenceValidationDiagram {
   public struct Clock {
     let queue: WorkQueue
@@ -33,6 +34,7 @@ public protocol TestInstant: Equatable {
   associatedtype Duration
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSequenceValidationDiagram.Clock {
   public struct Step: DurationProtocol, Hashable, CustomStringConvertible {
     internal var rawValue: Int
@@ -127,16 +129,20 @@ extension AsyncSequenceValidationDiagram.Clock {
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSequenceValidationDiagram.Clock.Instant: TestInstant {}
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension AsyncSequenceValidationDiagram.Clock.Instant: InstantProtocol {}
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSequenceValidationDiagram.Clock: TestClock {}
 
 @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 extension AsyncSequenceValidationDiagram.Clock: Clock {}
 
 // placeholders to avoid warnings
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSequenceValidationDiagram.Clock.Instant: Hashable {}
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSequenceValidationDiagram.Clock.Instant: Comparable {}

--- a/Sources/AsyncSequenceValidation/Event.swift
+++ b/Sources/AsyncSequenceValidation/Event.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSequenceValidationDiagram {
   struct Failure: Error, Equatable {}
 

--- a/Sources/AsyncSequenceValidation/Expectation.swift
+++ b/Sources/AsyncSequenceValidation/Expectation.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSequenceValidationDiagram {
   public struct ExpectationResult: Sendable {
     public struct Event: Sendable {

--- a/Sources/AsyncSequenceValidation/Input.swift
+++ b/Sources/AsyncSequenceValidation/Input.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSequenceValidationDiagram {
   public struct Specification: Sendable {
     public let specification: String

--- a/Sources/AsyncSequenceValidation/Job.swift
+++ b/Sources/AsyncSequenceValidation/Job.swift
@@ -11,6 +11,7 @@
 
 import _CAsyncSequenceValidationSupport
 
+@available(AsyncAlgorithms 1.0, *)
 struct Job: Hashable, @unchecked Sendable {
   let job: JobRef
 

--- a/Sources/AsyncSequenceValidation/TaskDriver.swift
+++ b/Sources/AsyncSequenceValidation/TaskDriver.swift
@@ -26,16 +26,19 @@ import Bionic
 #endif
 
 #if canImport(Darwin)
+@available(AsyncAlgorithms 1.0, *)
 func start_thread(_ raw: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer? {
   Unmanaged<TaskDriver>.fromOpaque(raw).takeRetainedValue().run()
   return nil
 }
 #elseif (canImport(Glibc) && !os(Android)) || canImport(Musl)
+@available(AsyncAlgorithms 1.0, *)
 func start_thread(_ raw: UnsafeMutableRawPointer?) -> UnsafeMutableRawPointer? {
   Unmanaged<TaskDriver>.fromOpaque(raw!).takeRetainedValue().run()
   return nil
 }
 #elseif os(Android)
+@available(AsyncAlgorithms 1.0, *)
 func start_thread(_ raw: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
   Unmanaged<TaskDriver>.fromOpaque(raw).takeRetainedValue().run()
   return UnsafeMutableRawPointer(bitPattern: 0xdeadbee)!
@@ -44,6 +47,7 @@ func start_thread(_ raw: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
 #error("TODO: Port TaskDriver threading to windows")
 #endif
 
+@available(AsyncAlgorithms 1.0, *)
 final class TaskDriver {
   let work: (TaskDriver) -> Void
   let queue: WorkQueue

--- a/Sources/AsyncSequenceValidation/Test.swift
+++ b/Sources/AsyncSequenceValidation/Test.swift
@@ -13,12 +13,14 @@ import _CAsyncSequenceValidationSupport
 import AsyncAlgorithms
 
 @_silgen_name("swift_job_run")
+@available(AsyncAlgorithms 1.0, *)
 @usableFromInline
 internal func _swiftJobRun(
   _ job: UnownedJob,
   _ executor: UnownedSerialExecutor
 )
 
+@available(AsyncAlgorithms 1.0, *)
 public protocol AsyncSequenceValidationTest: Sendable {
   var inputs: [AsyncSequenceValidationDiagram.Specification] { get }
   var output: AsyncSequenceValidationDiagram.Specification { get }
@@ -31,6 +33,7 @@ public protocol AsyncSequenceValidationTest: Sendable {
   ) async throws
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSequenceValidationDiagram {
   struct Test<Operation: AsyncSequence>: AsyncSequenceValidationTest, @unchecked Sendable
   where Operation.Element == String {

--- a/Sources/AsyncSequenceValidation/Theme.swift
+++ b/Sources/AsyncSequenceValidation/Theme.swift
@@ -9,18 +9,21 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 public protocol AsyncSequenceValidationTheme {
   func token(_ character: Character, inValue: Bool) -> AsyncSequenceValidationDiagram.Token
 
   func description(for token: AsyncSequenceValidationDiagram.Token) -> String
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSequenceValidationTheme where Self == AsyncSequenceValidationDiagram.ASCIITheme {
   public static var ascii: AsyncSequenceValidationDiagram.ASCIITheme {
     return AsyncSequenceValidationDiagram.ASCIITheme()
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 extension AsyncSequenceValidationDiagram {
   public enum Token: Sendable {
     case step

--- a/Sources/AsyncSequenceValidation/WorkQueue.swift
+++ b/Sources/AsyncSequenceValidation/WorkQueue.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(AsyncAlgorithms 1.0, *)
 struct WorkQueue: Sendable {
   enum Item: CustomStringConvertible, Comparable {
     case blocked(Token, AsyncSequenceValidationDiagram.Clock.Instant, UnsafeContinuation<Void, Error>)


### PR DESCRIPTION
Adding or raising the deployment platforms in the package manifest is a SemVer major breaking change as consumers must also add or raise their deployment platforms. This is a known limitation of SwiftPM.

Unforunately this means that it's very difficult for non-leaf packages to adopt packages which declare their platforms in the manifest. Doing so puts the brakes on adoption and ecosystem growth. For 'core' packages like this one availability constraints should be expressed on declarations rather than in the manifest.

This patch adds equivalent availability annotations to declarations across the package and removes platforms from the package manifest.