### PR TITLE
Fix AsyncBufferSequence leaking base sequence

### DIFF
--- a/Sources/AsyncAlgorithms/Buffer/BoundedBufferStorage.swift
+++ b/Sources/AsyncAlgorithms/Buffer/BoundedBufferStorage.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 @available(AsyncAlgorithms 1.0, *)
-final class BoundedBufferStorage<Base: AsyncSequence>: Sendable where Base: Sendable {
+struct BoundedBufferStorage<Base: AsyncSequence>: Sendable where Base: Sendable {
   private let stateMachine: ManagedCriticalState<BoundedBufferStateMachine<Base>>
 
   init(base: Base, limit: Int) {
@@ -152,7 +152,7 @@ final class BoundedBufferStorage<Base: AsyncSequence>: Sendable where Base: Send
     }
   }
 
-  deinit {
+  func iteratorDeinitialized() {
     self.interrupted()
   }
 }

--- a/Sources/AsyncAlgorithms/Buffer/UnboundedBufferStorage.swift
+++ b/Sources/AsyncAlgorithms/Buffer/UnboundedBufferStorage.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 @available(AsyncAlgorithms 1.0, *)
-final class UnboundedBufferStorage<Base: AsyncSequence>: Sendable where Base: Sendable {
+struct UnboundedBufferStorage<Base: AsyncSequence>: Sendable where Base: Sendable {
   private let stateMachine: ManagedCriticalState<UnboundedBufferStateMachine<Base>>
 
   init(base: Base, policy: UnboundedBufferStateMachine<Base>.Policy) {
@@ -120,7 +120,7 @@ final class UnboundedBufferStorage<Base: AsyncSequence>: Sendable where Base: Se
     }
   }
 
-  deinit {
+  func iteratorDeinitialized() {
     self.interrupted()
   }
 }


### PR DESCRIPTION
Currently, `AsyncBufferSequence` will leak the base sequence if iteration concludes without `next()` being cancelled. This is fixed by adopting an `InternalClass` inside the iterator which calls an `iteratorDeinitialized()` function on the storage, as done by other sequences in this package such as combine latest and merge.

The following code illustrates the issue: the assert fails meaning the channel has leaked.
```swift
let channel = AsyncChannel<Void>()
            
Task {
    for await _ in channel.buffer(policy: .bounded(1)) {
        break
    }
    
    Task { [weak channel] in
        assert(channel == nil)
    }
}

Task { [weak channel] in
    await channel?.send(())
}
```