### PR TITLE
Remove the DocC plugin as a dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -77,7 +77,6 @@ let package = Package(
 if Context.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
   package.dependencies += [
     .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
-    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
   ]
 } else {
   package.dependencies += [


### PR DESCRIPTION
When DocC was introduced the DocC plugin was useful for building documentation locally. Nowadays both Xcode and VSCode have built-in support to generate this without the need for the plugin.

This PR removes the direct dependency on the plugin.