### PR TITLE
Simplify the version definitions and add a new definition for 1.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,34 +4,11 @@ import PackageDescription
 import CompilerPluginSupport
 
 // Availability Macros
-let availabilityTags = [Availability("AsyncAlgorithms")]
-let versionNumbers = ["1.0"]
 
-// Availability Macro Utilities
-enum OSAvailability: String {
-  // This should match the package's deployment target
-  case initialIntroduction = "macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0"
-  case pending = "macOS 9999, iOS 9999, tvOS 9999, watchOS 9999"
-  // Use 10000 for future availability to avoid compiler magic around
-  // the 9999 version number but ensure it is greater than 9999
-  case future = "macOS 10000, iOS 10000, tvOS 10000, watchOS 10000"
-}
-
-struct Availability {
-  let name: String
-  let osAvailability: OSAvailability
-
-  init(_ name: String, availability: OSAvailability = .initialIntroduction) {
-    self.name = name
-    self.osAvailability = availability
-  }
-}
-
-let availabilityMacros: [SwiftSetting] = versionNumbers.flatMap { version in
-  availabilityTags.map {
-    .enableExperimentalFeature("AvailabilityMacro=\($0.name) \(version):\($0.osAvailability.rawValue)")
-  }
-}
+let availabilityMacros: [SwiftSetting] = [
+  .enableExperimentalFeature("AvailabilityMacro=AsyncAlgorithms 1.0:macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0"),
+  .enableExperimentalFeature("AvailabilityMacro=AsyncAlgorithms 1.1:macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0"),
+]
 
 let package = Package(
   name: "swift-async-algorithms",


### PR DESCRIPTION
The existing definitions for the versions was lifted directly from Swift-Foundation and was overly complex for AsyncAlgorithms. This simplifies it and introduces a new version id of 1.1 defined as macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0 *.