### PR TITLE
Add `enable_wasm_sdk_build: true` to `pull_request.yml`

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,6 +8,10 @@ jobs:
   tests:
     name: Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    with:
+      enable_wasm_sdk_build: true
+      wasm_sdk_build_command: swift build -Xcc -D_WASI_EMULATED_PTHREAD
+
   soundness:
     name: Soundness
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main

--- a/Sources/AsyncAlgorithms/Locking.swift
+++ b/Sources/AsyncAlgorithms/Locking.swift
@@ -19,6 +19,8 @@ import Musl
 import WinSDK
 #elseif canImport(Bionic)
 import Bionic
+#elseif canImport(wasi_pthread)
+import wasi_pthread
 #else
 #error("Unsupported platform")
 #endif
@@ -26,7 +28,7 @@ import Bionic
 internal struct Lock {
   #if canImport(Darwin)
   typealias Primitive = os_unfair_lock
-  #elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+  #elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic) || canImport(wasi_pthread)
   typealias Primitive = pthread_mutex_t
   #elseif canImport(WinSDK)
   typealias Primitive = SRWLOCK
@@ -44,7 +46,7 @@ internal struct Lock {
   fileprivate static func initialize(_ platformLock: PlatformLock) {
     #if canImport(Darwin)
     platformLock.initialize(to: os_unfair_lock())
-    #elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+    #elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic) || canImport(wasi_pthread)
     let result = pthread_mutex_init(platformLock, nil)
     precondition(result == 0, "pthread_mutex_init failed")
     #elseif canImport(WinSDK)
@@ -55,7 +57,7 @@ internal struct Lock {
   }
 
   fileprivate static func deinitialize(_ platformLock: PlatformLock) {
-    #if canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+    #if canImport(Glibc) || canImport(Musl) || canImport(Bionic) || canImport(wasi_pthread)
     let result = pthread_mutex_destroy(platformLock)
     precondition(result == 0, "pthread_mutex_destroy failed")
     #endif
@@ -65,7 +67,7 @@ internal struct Lock {
   fileprivate static func lock(_ platformLock: PlatformLock) {
     #if canImport(Darwin)
     os_unfair_lock_lock(platformLock)
-    #elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+    #elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic) || canImport(wasi_pthread)
     pthread_mutex_lock(platformLock)
     #elseif canImport(WinSDK)
     AcquireSRWLockExclusive(platformLock)
@@ -77,7 +79,7 @@ internal struct Lock {
   fileprivate static func unlock(_ platformLock: PlatformLock) {
     #if canImport(Darwin)
     os_unfair_lock_unlock(platformLock)
-    #elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+    #elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic) || canImport(wasi_pthread)
     let result = pthread_mutex_unlock(platformLock)
     precondition(result == 0, "pthread_mutex_unlock failed")
     #elseif canImport(WinSDK)

--- a/Sources/_CAsyncSequenceValidationSupport/_CAsyncSequenceValidationSupport.h
+++ b/Sources/_CAsyncSequenceValidationSupport/_CAsyncSequenceValidationSupport.h
@@ -246,3 +246,14 @@ SWIFT_EXPORT_FROM(swift_Concurrency)
 SWIFT_CC(swift) void (* _Nullable swift_task_enqueueGlobal_hook)(
   JobRef _Nonnull job, swift_task_enqueueGlobal_original _Nonnull original);
 
+// Workaround for `macro 'pthread_join' unavailable: function like macros not supported`
+#if defined(__wasi__)
+
+#include <pthread.h>
+
+int swift_async_sequencey_pthread_join(pthread_t thread, void **value_ptr) {
+  return pthread_join(thread, value_ptr);
+}
+
+#endif
+


### PR DESCRIPTION
`swift-async-algorithms` should be built for Wasm as one of the officially supported platforms on CI to prevent possible future regressions.