### PR TITLE
Add .editorconfig for consistent coding style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+


### PR DESCRIPTION
This change makes Xcode and other supporting editors automatically indent by 2 spaces; see https://github.com/swiftlang/swift/blob/main/.editorconfig.