### PR TITLE
Fix swift tool version in Package.swift@5.7 

### DIFF
--- a/Package@swift-5.7.swift
+++ b/Package@swift-5.7.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 5.7
 
 import PackageDescription
 


### PR DESCRIPTION
Hi there 
At the moment, the version in the manifest does not match the one specified in the file name.
An incorrect version of the swift tool may cause syntax problems when using its own registry.
