### PR TITLE
Remove the Swift 5.8 build constraint for documentation at Swift Package Index

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -2,4 +2,3 @@ version: 1
 builder:
   configs:
     - documentation_targets: [AsyncAlgorithms]
-      swift_version: 5.8


### PR DESCRIPTION
With the existing .spi.yml docs setup constrained to Swift 5.8, symbols that are only available in later versions (for example, MultiProducerSingleConsumerAsyncChannel) are reflected in the hosted documentation.