### PR TITLE
Make `MPSCAsyncChannel` source methods `nonisolated(nonsending)`

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,4 +22,4 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
     with:
       license_header_check_project_name: "Swift Async Algorithms"
-      format_check_container_image: "swiftlang/swift:nightly-6.1-noble"  # Needed since 6.0.x doesn't support sending keyword
+      format_check_container_image: "swiftlang/swift:nightly-main-noble"  # Needed due to https://github.com/swiftlang/swift-format/issues/1081


### PR DESCRIPTION
`nonisolated(nonsending)` is a 6.2 language feature that allows the inheritance of the callers isolation. The new `MPSCAsyncChannel.Source` send methods should adopt this to avoid unnecessary isolation hops.