### PR TITLE
Make MPSCAsyncChannel `#isolation` methods use nonisolated(nonsending)`.

### DIFF
--- a/Sources/AsyncAlgorithms/MultiProducerSingleConsumerChannel/MultiProducerSingleConsumerAsyncChannel+Internal.swift
+++ b/Sources/AsyncAlgorithms/MultiProducerSingleConsumerChannel/MultiProducerSingleConsumerAsyncChannel+Internal.swift
@@ -391,7 +391,7 @@ extension MultiProducerSingleConsumerAsyncChannel {
     }
 
     @inlinable
-    func next(isolation: isolated (any Actor)? = #isolation) async throws -> Element? {
+    nonisolated(nonsending) func next() async throws -> Element? {
       let action = self._stateMachine.withLock {
         $0.next()
       }
@@ -431,7 +431,7 @@ extension MultiProducerSingleConsumerAsyncChannel {
     }
 
     @inlinable
-    func suspendNext(isolation: isolated (any Actor)? = #isolation) async throws -> Element? {
+    nonisolated(nonsending) func suspendNext() async throws -> Element? {
       try await withTaskCancellationHandler {
         try await withUnsafeThrowingContinuation { (continuation: UnsafeContinuation<Element?, Error>) in
           let action = self._stateMachine.withLock {

--- a/Sources/AsyncAlgorithms/MultiProducerSingleConsumerChannel/MultiProducerSingleConsumerAsyncChannel.swift
+++ b/Sources/AsyncAlgorithms/MultiProducerSingleConsumerChannel/MultiProducerSingleConsumerAsyncChannel.swift
@@ -201,9 +201,7 @@ public struct MultiProducerSingleConsumerAsyncChannel<Element, Failure: Error>: 
   /// - Parameter isolation: The callers isolation.
   /// - Returns: The next buffered element.
   @inlinable
-  public mutating func next(
-    isolation: isolated (any Actor)? = #isolation
-  ) async throws(Failure) -> Element? {
+  nonisolated(nonsending) public mutating func next() async throws(Failure) -> Element? {
     do {
       return try await self.storage.next()
     } catch {
@@ -710,9 +708,7 @@ extension MultiProducerSingleConsumerAsyncChannel.ChannelAsyncSequence where Ele
     }
 
     @inlinable
-    mutating func next(
-      isolation actor: isolated (any Actor)? = #isolation
-    ) async throws(Failure) -> Element? {
+    nonisolated(nonsending) mutating func next() async throws(Failure) -> Element? {
       do {
         return try await self._backing.storage.next(isolation: actor)
       } catch {


### PR DESCRIPTION
We can perform more aggressive optimizer optimizations with nonisolated(nonsending) than #isolation. So use that instead to get some easy perf wins.