### PR TITLE
Support for Wasm using Swift SDKs that don't support pthreads

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,7 +15,6 @@ jobs:
       linux_exclude_swift_versions: "[{\"swift_version\": \"5.9\"}, {\"swift_version\": \"5.10\"}]]"
       windows_exclude_swift_versions: "[{\"swift_version\": \"5.9\"}]"
       enable_wasm_sdk_build: true
-      wasm_sdk_build_command: swift build -Xcc -D_WASI_EMULATED_PTHREAD
 
   soundness:
     name: Soundness


### PR DESCRIPTION
# Summary

This PR adds support for compiling `swift-async-algorithms` to wasm using the [Swift SDK for WebAssembly](https://www.swift.org/documentation/articles/wasm-getting-started.html) - but without pthreads and specialized command such as `swift build -Xcc -D_WASI_EMULATED_PTHREAD`.

This is achieved by eliding mutex locking for single-thread non-pthread WASI platforms, similar to the approach used in [swift-log](https://github.com/apple/swift-log/blob/main/Sources/Logging/Locks.swift#L30). This enables building `swift-async-algorithms` with the default Swift for WebAssembly configurations

This PR is [part of a larger effort](https://github.com/PassiveLogic/swift-web-examples/issues/1) by a company called PassiveLogic to enable broad support for Swift WebAssembly compilation.

# Details

- Added additional compilation conditionals to elide mutex locking for WASI platforms that lack pthread support and carry a decently strong guarantee of single-threaded operation.
- Removed specialized wasm build command customization from CI configuration, since `swift-async-algorithms` will now compile with the vanilla default configuration with these changes.

# Testing done

- [x] Cleaned up swiftformat lint on modified lines of change.
- [x] Verified unit tests still pass with these changes
- [x] Verified `swift build` completes without errors
- [x] Verified `swift build --swift-sdk wasm32-unknown-wasip1 --target AsyncAlgorithms` completes without errors
- [x] Verified `swift build --swift-sdk wasm32-unknown-wasip1-threads --target AsyncAlgorithms` completes without errors
- [x] Verified CI passes using [CI check on separate draft PR](https://github.com/PassiveLogic/swift-async-algorithms/actions/runs/20287929178/job/58265876675?pr=1)

# Impact Risk

There should be no negeative impact risk for existing targets. The changes only affect compilation for WASI platforms that don't support pthread, which was previously unsupported.