### PR TITLE
Fix a data race error with the internal `Optional.takeSending`

### DIFF
--- a/Sources/AsyncAlgorithms/Internal/Disconnected.swift
+++ b/Sources/AsyncAlgorithms/Internal/Disconnected.swift
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Async Algorithms open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=6.1)
+// This is a helper type to move a non-Sendable value across isolation regions.
+@usableFromInline
+struct Disconnected<Value: ~Copyable>: ~Copyable, Sendable {
+  // This is safe since we take the value as sending and take consumes it
+  // and returns it as sending.
+  private nonisolated(unsafe) var value: Value?
+
+  @usableFromInline
+  init(value: consuming sending Value) {
+    self.value = .some(value)
+  }
+
+  @usableFromInline
+  consuming func take() -> sending Value {
+    nonisolated(unsafe) let value = self.value.take()!
+    return value
+  }
+
+  @usableFromInline
+  mutating func swap(newValue: consuming sending Value) -> sending Value {
+    nonisolated(unsafe) let value = self.value.take()!
+    self.value = consume newValue
+    return value
+  }
+}
+#endif

--- a/Sources/AsyncAlgorithms/MultiProducerSingleConsumerChannel/MultiProducerSingleConsumerAsyncChannel.swift
+++ b/Sources/AsyncAlgorithms/MultiProducerSingleConsumerChannel/MultiProducerSingleConsumerAsyncChannel.swift
@@ -138,23 +138,24 @@ public struct MultiProducerSingleConsumerAsyncChannel<Element, Failure: Error>: 
   public struct ChannelAndStream: ~Copyable {
     /// The channel.
     @usableFromInline
-    var channel: MultiProducerSingleConsumerAsyncChannel?
+    var channel: Disconnected<MultiProducerSingleConsumerAsyncChannel?>
 
     /// Takes and returns the channel.
     ///
     /// - Important: If this is called more than once it will result in a runtime crash.
     @inlinable
     public mutating func takeChannel() -> sending MultiProducerSingleConsumerAsyncChannel {
-      return self.channel.takeSending()!
+      var channel = self.channel.swap(newValue: nil)
+      return channel.take()!
     }
     /// The source.
     public var source: Source
 
     init(
-      channel: consuming MultiProducerSingleConsumerAsyncChannel,
+      channel: consuming sending MultiProducerSingleConsumerAsyncChannel,
       source: consuming Source
     ) {
-      self.channel = .some(channel)
+      self.channel = Disconnected(value: channel)
       self.source = source
     }
   }


### PR DESCRIPTION
We added a little helper to move a non-Sendable type into an optional and take it out as sending so that it is disconnected. This was actually a data race hole which got fixed by the compiler so we need to use a proper disconnected abstractions.