### PR TITLE
Add missing availability annotations to TestClock and TestInstant

### DIFF
--- a/Sources/AsyncSequenceValidation/Clock.swift
+++ b/Sources/AsyncSequenceValidation/Clock.swift
@@ -22,6 +22,7 @@ extension AsyncSequenceValidationDiagram {
   }
 }
 
+@available(AsyncAlgorithms 1.0, *)
 public protocol TestClock: Sendable {
   associatedtype Instant: TestInstant
 
@@ -30,6 +31,7 @@ public protocol TestClock: Sendable {
   func sleep(until deadline: Self.Instant, tolerance: Self.Instant.Duration?) async throws
 }
 
+@available(AsyncAlgorithms 1.0, *)
 public protocol TestInstant: Equatable {
   associatedtype Duration
 }

--- a/Tests/AsyncAlgorithmsTests/MultiProducerSingleConsumerChannel/MultiProducerSingleConsumerAsyncChannelTests.swift
+++ b/Tests/AsyncAlgorithmsTests/MultiProducerSingleConsumerChannel/MultiProducerSingleConsumerAsyncChannelTests.swift
@@ -971,7 +971,7 @@ final class MultiProducerSingleConsumerAsyncChannelTests: XCTestCase {
         backpressureStrategy: .watermark(low: 2, high: 4)
       )
       let channel = channelAndSource.takeChannel()
-      var source: MultiProducerSingleConsumerAsyncChannel.Source! = consume channelAndSource.source
+      var source: MultiProducerSingleConsumerAsyncChannel<Int, Never>.Source! = consume channelAndSource.source
 
       group.addTask {
         var source = source.take()!


### PR DESCRIPTION
## Summary

- When the `platforms:` field was removed from Package.swift in favor of availability annotations (#348), `TestClock` and `TestInstant` protocols in `AsyncSequenceValidation/Clock.swift` were missed.
- Without `platforms:`, SwiftPM's default deployment target depends on the toolchain. Nightly/dev toolchains (used by ci.swift.org) default to macOS 10.13, which is below the macOS 10.15 minimum for `async/await`. Xcode release toolchains default to a higher target, which is why this doesn't reproduce locally with a stock `swift build`.
- This [has kept ci.swift.org macOS builds](https://ci.swift.org/job/pr-swift-async-algorithms-macos/) red since #348 landed (April 2025).
- Adds `@available(AsyncAlgorithms 1.0, *)` to both protocols, matching every other public declaration in the module.

## Reproducing locally

```
swift build -Xswiftc -target -Xswiftc x86_64-apple-macos10.13
```

## Test plan

- [x] `swift build` succeeds locally
- [x] Build with explicit macOS 10.13 target succeeds after fix
- [ ] ci.swift.org macOS CI passes