### PR TITLE
Rework `AsyncStreaming` protocols to use generic `RangeReplaceableCon…

### DIFF
--- a/Sources/AsyncStreaming/NNNN-async-streaming.md
+++ b/Sources/AsyncStreaming/NNNN-async-streaming.md
@@ -147,7 +147,7 @@ The bite-sized pseudocode:
 
 ```
 protocol AsyncReader {
-    // Callee provides a full buffer; caller processes it
+    // Callee provides a full buffer; caller drains it
     func read(body: (inout buffer) throws -> R) throws -> R
 }
 


### PR DESCRIPTION
…tainer` buffers

Replace `InputSpan`/`OutputSpan` with generic `Buffer` associated types constrained to `RangeReplaceableContainer` across all four streaming protocols. This sidesteps the limitation that `OutputSpan` (and other `~Escapable` types) cannot be used in async contexts today, while still allowing conforming types to choose a buffer representation optimized for their use case (e.g. `UniqueArray` for heap-backed storage, or a future stack-allocated container for embedded).

Switch callee-owned protocols from `consuming` to `inout` closure semantics, rename `forEachChunk` to `forEachBuffer`, and move `forEach`/`collect` to future directions in the proposal.

Adds test coverage for `AsyncWriter`, `CallerAsyncReader`, and `EitherError`. Updates all documentation to reflect the new API surface.