### PR TITLE
Change all AsyncStreaming availability from 26.2 to SwiftStdlib 5.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -163,7 +163,7 @@ if Context.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
   package.dependencies += [
     .package(
       url: "https://github.com/apple/swift-collections.git",
-      from: "1.5.0",
+      from: "1.5.1",
       traits: [.trait(name: "UnstableContainersPreview", condition: .when(traits: ["UnstableAsyncStreaming"]))]
     )
   ]

--- a/Sources/AsyncStreaming/AsyncReader/AsyncReader+collect.swift
+++ b/Sources/AsyncStreaming/AsyncReader/AsyncReader+collect.swift
@@ -22,7 +22,7 @@ public struct AsyncReaderLeftOverElementsError: Error, Hashable {
   public init() {}
 }
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
 extension AsyncReader where Self: ~Copyable, Self: ~Escapable, ReadElement: ~Copyable {
   /// Collects elements from the reader up to a specified limit and processes them.
   ///

--- a/Sources/AsyncStreaming/AsyncReader/AsyncReader+forEach.swift
+++ b/Sources/AsyncStreaming/AsyncReader/AsyncReader+forEach.swift
@@ -14,7 +14,7 @@
 public import ContainersPreview
 
 // swift-format-ignore: AmbiguousTrailingClosureOverload
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
 extension AsyncReader where Self: ~Copyable, Self: ~Escapable {
   /// Iterates over all chunks from the reader, executing the provided body for each buffer.
   ///

--- a/Sources/AsyncStreaming/AsyncReader/AsyncReader.swift
+++ b/Sources/AsyncStreaming/AsyncReader/AsyncReader.swift
@@ -17,7 +17,7 @@ public import ContainersPreview
 /// Adopt ``AsyncReader`` when you need callee-managed buffering,
 /// where the reader controls the buffer and passes it to the caller
 /// through the `body` closure.
-@available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.0, *)
+@available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
 public protocol AsyncReader<ReadElement, ReadFailure>: ~Copyable, ~Escapable {
   /// The type of elements this reader reads.
   associatedtype ReadElement: ~Copyable

--- a/Sources/AsyncStreaming/AsyncWriter/AsyncWriter.swift
+++ b/Sources/AsyncStreaming/AsyncWriter/AsyncWriter.swift
@@ -17,7 +17,7 @@ public import ContainersPreview
 /// Adopt ``AsyncWriter`` when you need callee-managed buffering,
 /// where the writer supplies a buffer that the caller fills
 /// with elements to write.
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
+@available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
 public protocol AsyncWriter<WriteElement, WriteFailure>: ~Copyable, ~Escapable {
   /// The type of elements this writer writes.
   associatedtype WriteElement: ~Copyable

--- a/Sources/AsyncStreaming/CallerAsyncReader/CallerAsyncReader.swift
+++ b/Sources/AsyncStreaming/CallerAsyncReader/CallerAsyncReader.swift
@@ -17,7 +17,7 @@ public import ContainersPreview
 /// Adopt ``CallerAsyncReader`` when you need caller-managed buffering,
 /// where the caller supplies a buffer that the reader fills
 /// with elements.
-@available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.0, *)
+@available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
 public protocol CallerAsyncReader<ReadElement, ReadFailure>: ~Copyable, ~Escapable {
   /// The type of elements this reader reads.
   associatedtype ReadElement: ~Copyable

--- a/Sources/AsyncStreaming/CallerAsyncWriter/CallerAsyncWriter.swift
+++ b/Sources/AsyncStreaming/CallerAsyncWriter/CallerAsyncWriter.swift
@@ -17,7 +17,7 @@ public import ContainersPreview
 /// Adopt ``CallerAsyncWriter`` when you need caller-managed buffering,
 /// where the caller provides a buffer of elements for the writer
 /// to consume.
-@available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.0, *)
+@available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, *)
 public protocol CallerAsyncWriter<WriteElement, WriteFailure>: ~Copyable, ~Escapable {
   /// The type of elements this writer writes.
   associatedtype WriteElement: ~Copyable

--- a/Tests/AsyncAlgorithmsTests/MultiProducerSingleConsumerChannel/MultiProducerSingleConsumerAsyncChannelTests.swift
+++ b/Tests/AsyncAlgorithmsTests/MultiProducerSingleConsumerChannel/MultiProducerSingleConsumerAsyncChannelTests.swift
@@ -962,7 +962,7 @@ final class MultiProducerSingleConsumerAsyncChannelTests: XCTestCase {
     _ = await iterator.next(isolation: nil)
   }
 
-  func testWatermarWithLotsOfElements() async throws {
+  func testWatermarkWithLotsOfElements() async throws {
     await withThrowingTaskGroup(of: Void.self) { group in
       // This test should in the future use a custom task executor to schedule to avoid sending
       // 1000 elements.

--- a/Tests/AsyncAlgorithmsTests/MultiProducerSingleConsumerChannel/MultiProducerSingleConsumerAsyncChannelTests.swift
+++ b/Tests/AsyncAlgorithmsTests/MultiProducerSingleConsumerChannel/MultiProducerSingleConsumerAsyncChannelTests.swift
@@ -971,7 +971,7 @@ final class MultiProducerSingleConsumerAsyncChannelTests: XCTestCase {
         backpressureStrategy: .watermark(low: 2, high: 4)
       )
       let channel = channelAndSource.takeChannel()
-      var source: MultiProducerSingleConsumerAsyncChannel.Source! = consume channelAndSource.source
+      var source: MultiProducerSingleConsumerAsyncChannel.Source? = consume channelAndSource.source
 
       group.addTask {
         var source = source.take()!

--- a/Tests/AsyncStreamingTests/AsyncReader/AsyncReader+collectTests.swift
+++ b/Tests/AsyncStreamingTests/AsyncReader/AsyncReader+collectTests.swift
@@ -19,7 +19,6 @@ import Testing
 @Suite
 struct AsyncReaderCollectTests {
   @Test
-  @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
   func collectAllElements() async throws {
     var reader = UniqueArrayAsyncReader(storage: UniqueArray(capacity: 5, copying: [1, 2, 3, 4, 5]))
 
@@ -31,7 +30,6 @@ struct AsyncReaderCollectTests {
   }
 
   @Test
-  @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
   func collectWithExactLimit() async throws {
     var reader = UniqueArrayAsyncReader(storage: UniqueArray(capacity: 5, copying: [1, 2, 3, 4, 5]))
 
@@ -43,7 +41,6 @@ struct AsyncReaderCollectTests {
   }
 
   @Test
-  @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
   func collectEmptyReader() async throws {
     var reader = UniqueArrayAsyncReader(storage: UniqueArray(capacity: 0, copying: []))
 
@@ -55,7 +52,6 @@ struct AsyncReaderCollectTests {
   }
 
   @Test
-  @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
   func collectProcessesAllElements() async throws {
     var reader = UniqueArrayAsyncReader(storage: UniqueArray(capacity: 3, copying: [10, 20, 30]))
 
@@ -71,7 +67,6 @@ struct AsyncReaderCollectTests {
   }
 
   @Test
-  @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
   func collectThrowsLeftOverElements() async throws {
     var reader = UniqueArrayAsyncReader(storage: UniqueArray(capacity: 3, copying: [1, 2, 3]))
 

--- a/Tests/AsyncStreamingTests/AsyncReader/AsyncReader+forEachTests.swift
+++ b/Tests/AsyncStreamingTests/AsyncReader/AsyncReader+forEachTests.swift
@@ -19,7 +19,6 @@ import Testing
 @Suite
 struct AsyncReaderforEachBufferTests {
   @Test
-  @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
   func forEachBufferIteratesAllSpans() async throws {
     let reader = UniqueArrayAsyncReader(storage: UniqueArray(capacity: 5, copying: [1, 2, 3, 4, 5]))
     var elementCount = 0
@@ -32,7 +31,6 @@ struct AsyncReaderforEachBufferTests {
   }
 
   @Test
-  @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
   func forEachBufferProcessesElements() async throws {
     let reader = UniqueArrayAsyncReader(storage: UniqueArray(capacity: 3, copying: [10, 20, 30]))
     var sum = 0
@@ -47,7 +45,6 @@ struct AsyncReaderforEachBufferTests {
   }
 
   @Test
-  @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
   func forEachBufferWithEmptyReader() async throws {
     let reader = UniqueArrayAsyncReader(storage: UniqueArray(capacity: 0, copying: []))
     var callCount = 0
@@ -60,7 +57,6 @@ struct AsyncReaderforEachBufferTests {
   }
 
   @Test
-  @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
   func forEachBufferWithThrowingBody() async {
     enum TestError: Error {
       case failed
@@ -79,7 +75,6 @@ struct AsyncReaderforEachBufferTests {
   }
 
   @Test
-  @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
   func forEachBufferWithNeverFailingReader() async {
     enum TestError: Error {
       case failed
@@ -100,7 +95,6 @@ struct AsyncReaderforEachBufferTests {
   }
 
   @Test
-  @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
   func forEachBufferWithAsyncWork() async throws {
     let reader = UniqueArrayAsyncReader(storage: UniqueArray(capacity: 3, copying: [1, 2, 3]))
     var results: [Int] = []

--- a/Tests/AsyncStreamingTests/AsyncReader/AsyncReaderTests.swift
+++ b/Tests/AsyncStreamingTests/AsyncReader/AsyncReaderTests.swift
@@ -18,7 +18,6 @@ import Testing
 @Suite
 struct AsyncReaderTests {
   @Test
-  @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
   func read() async {
     var reader = UniqueArrayAsyncReader(storage: UniqueArray(capacity: 5, copying: [1, 2, 3, 4, 5]))
 
@@ -35,7 +34,6 @@ struct AsyncReaderTests {
   }
 
   @Test
-  @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
   func readEmptyAtEnd() async {
     var reader = UniqueArrayAsyncReader(storage: UniqueArray(capacity: 3, copying: [1, 2, 3]))
 

--- a/Tests/AsyncStreamingTests/AsyncWriter/AsyncWriterTests.swift
+++ b/Tests/AsyncStreamingTests/AsyncWriter/AsyncWriterTests.swift
@@ -18,7 +18,6 @@ import Testing
 @Suite
 struct AsyncWriterTests {
   @Test
-  @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
   func writeElements() async {
     var writer = UniqueArrayAsyncWriter()
 
@@ -35,7 +34,6 @@ struct AsyncWriterTests {
   }
 
   @Test
-  @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
   func writeEmptyBuffer() async {
     var writer = UniqueArrayAsyncWriter()
 
@@ -45,7 +43,6 @@ struct AsyncWriterTests {
   }
 
   @Test
-  @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
   func writeReturnsValue() async {
     var writer = UniqueArrayAsyncWriter()
 
@@ -60,7 +57,6 @@ struct AsyncWriterTests {
   }
 
   @Test
-  @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
   func writeWithThrowingBody() async {
     enum TestError: Error, Equatable {
       case failed
@@ -79,7 +75,6 @@ struct AsyncWriterTests {
   }
 
   @Test
-  @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
   func writeMultipleTimes() async {
     var writer = UniqueArrayAsyncWriter()
 

--- a/Tests/AsyncStreamingTests/CallerAsyncReader/CallerAsyncReaderTests.swift
+++ b/Tests/AsyncStreamingTests/CallerAsyncReader/CallerAsyncReaderTests.swift
@@ -18,7 +18,6 @@ import Testing
 @Suite
 struct CallerAsyncReaderTests {
   @Test
-  @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
   func readIntoBuffer() async {
     var reader = UniqueArrayCallerAsyncReader(
       storage: UniqueArray(capacity: 5, copying: [1, 2, 3, 4, 5])
@@ -36,7 +35,6 @@ struct CallerAsyncReaderTests {
   }
 
   @Test
-  @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
   func readIntoBufferAtEnd() async {
     var reader = UniqueArrayCallerAsyncReader(
       storage: UniqueArray(capacity: 0, copying: [])
@@ -49,7 +47,6 @@ struct CallerAsyncReaderTests {
   }
 
   @Test
-  @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
   func readIntoBufferRespectsCapacity() async {
     var reader = UniqueArrayCallerAsyncReader(
       storage: UniqueArray(capacity: 10, copying: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
@@ -65,7 +62,6 @@ struct CallerAsyncReaderTests {
   }
 
   @Test
-  @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
   func readMultipleTimes() async {
     var reader = UniqueArrayCallerAsyncReader(
       storage: UniqueArray(capacity: 6, copying: [1, 2, 3, 4, 5, 6])

--- a/Tests/AsyncStreamingTests/CallerAsyncWriter/CallerAsyncWriterTests.swift
+++ b/Tests/AsyncStreamingTests/CallerAsyncWriter/CallerAsyncWriterTests.swift
@@ -18,7 +18,6 @@ import Testing
 @Suite
 struct CallerAsyncWriterTests {
   @Test
-  @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
   func writeBuffer() async {
     var writer = UniqueArrayCallerAsyncWriter()
     var data = UniqueArray(capacity: 5, copying: [1, 2, 3, 4, 5])
@@ -29,7 +28,6 @@ struct CallerAsyncWriterTests {
   }
 
   @Test
-  @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
   func writeEmptyBuffer() async {
     var writer = UniqueArrayCallerAsyncWriter()
     var data = UniqueArray<Int>()
@@ -40,7 +38,6 @@ struct CallerAsyncWriterTests {
   }
 
   @Test
-  @available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
   func writeLargeBuffer() async {
     var writer = UniqueArrayCallerAsyncWriter(capacity: 100)
     var data = UniqueArray(capacity: 5, copying: Array(1...50))

--- a/Tests/AsyncStreamingTests/Helpers/UniqueArrayAsyncReader.swift
+++ b/Tests/AsyncStreamingTests/Helpers/UniqueArrayAsyncReader.swift
@@ -14,7 +14,6 @@ import AsyncStreaming
 import BasicContainers
 import ContainersPreview
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 struct UniqueArrayAsyncReader: ~Copyable, AsyncReader {
   typealias ReadElement = Int
   typealias Buffer = UniqueArray<Int>

--- a/Tests/AsyncStreamingTests/Helpers/UniqueArrayAsyncWriter.swift
+++ b/Tests/AsyncStreamingTests/Helpers/UniqueArrayAsyncWriter.swift
@@ -14,7 +14,6 @@ import AsyncStreaming
 import BasicContainers
 import ContainersPreview
 
-@available(macOS 26.2, iOS 26.2, watchOS 26.2, tvOS 26.2, visionOS 26.2, *)
 struct UniqueArrayAsyncWriter: ~Copyable, AsyncWriter {
   typealias WriteElement = Int
   typealias Buffer = UniqueArray<Int>

--- a/Tests/AsyncStreamingTests/Helpers/UniqueArrayCallerAsyncReader.swift
+++ b/Tests/AsyncStreamingTests/Helpers/UniqueArrayCallerAsyncReader.swift
@@ -14,7 +14,6 @@ import AsyncStreaming
 import BasicContainers
 import ContainersPreview
 
-@available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.0, *)
 struct UniqueArrayCallerAsyncReader: ~Copyable, CallerAsyncReader {
   typealias ReadElement = Int
   typealias ReadFailure = Never

--- a/Tests/AsyncStreamingTests/Helpers/UniqueArrayCallerAsyncWriter.swift
+++ b/Tests/AsyncStreamingTests/Helpers/UniqueArrayCallerAsyncWriter.swift
@@ -16,7 +16,6 @@ import ContainersPreview
 
 struct WriterCapacityError: Error {}
 
-@available(macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.0, *)
 struct UniqueArrayCallerAsyncWriter: ~Copyable, CallerAsyncWriter {
   typealias WriteElement = Int
   typealias WriteFailure = Never


### PR DESCRIPTION
I tested this with the latest compiler snapshot (5-17) and it builds fine. The availability isn't actually required in the test target, presumably because the oldest deployment target it supports is macOS 12.0 aligned.