### PR TITLE
Correct exclusive reductions docs: the initial value is not emitted

### DIFF
--- a/Sources/AsyncAlgorithms/AsyncExclusiveReductionsSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncExclusiveReductionsSequence.swift
@@ -14,15 +14,18 @@ extension AsyncSequence {
   /// Returns an asynchronous sequence containing the accumulated results of combining the
   /// elements of the asynchronous sequence using the given closure.
   ///
-  /// This can be seen as applying the reduce function to each element and
-  /// providing the initial value followed by these results as an asynchronous sequence.
+  /// Starting from the initial value, this combines each element of the base
+  /// asynchronous sequence with the running result and emits each intermediate
+  /// result. The initial value itself is not emitted, so the first element of
+  /// the returned sequence is the result of combining the initial value with
+  /// the first element of the base sequence. If the base sequence is empty, the
+  /// returned sequence is also empty.
   ///
   /// - Parameters:
   ///   - initial: The value to use as the initial value.
   ///   - transform: A closure that combines the previously-reduced result and
   ///     the next element in the receiving asynchronous sequence, which it returns.
-  /// - Returns: An asynchronous sequence of the initial value followed by the reduced
-  ///   elements.
+  /// - Returns: An asynchronous sequence of the reduced elements.
   @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func reductions<Result>(
@@ -37,16 +40,19 @@ extension AsyncSequence {
   /// Returns an asynchronous sequence containing the accumulated results of combining the
   /// elements of the asynchronous sequence using the given closure.
   ///
-  /// This can be seen as applying the reduce function to each element and
-  /// providing the initial value followed by these results as an asynchronous sequence.
+  /// Starting from the initial value, this combines each element of the base
+  /// asynchronous sequence with the running result and emits each intermediate
+  /// result. The initial value itself is not emitted, so the first element of
+  /// the returned sequence is the result of combining the initial value with
+  /// the first element of the base sequence. If the base sequence is empty, the
+  /// returned sequence is also empty.
   ///
   /// - Parameters:
   ///   - initial: The value to use as the initial value.
   ///   - transform: A closure that combines the previously-reduced result and
   ///     the next element in the receiving asynchronous sequence, mutating the
   ///     previous result instead of returning a value.
-  /// - Returns: An asynchronous sequence of the initial value followed by the reduced
-  ///   elements.
+  /// - Returns: An asynchronous sequence of the reduced elements.
   @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func reductions<Result>(

--- a/Sources/AsyncAlgorithms/AsyncThrowingExclusiveReductionsSequence.swift
+++ b/Sources/AsyncAlgorithms/AsyncThrowingExclusiveReductionsSequence.swift
@@ -14,16 +14,19 @@ extension AsyncSequence {
   /// Returns an asynchronous sequence containing the accumulated results of combining the
   /// elements of the asynchronous sequence using the given error-throwing closure.
   ///
-  /// This can be seen as applying the reduce function to each element and
-  /// providing the initial value followed by these results as an asynchronous sequence.
+  /// Starting from the initial value, this combines each element of the base
+  /// asynchronous sequence with the running result and emits each intermediate
+  /// result. The initial value itself is not emitted, so the first element of
+  /// the returned sequence is the result of combining the initial value with
+  /// the first element of the base sequence. If the base sequence is empty, the
+  /// returned sequence is also empty.
   ///
   /// - Parameters:
   ///   - initial: The value to use as the initial value.
   ///   - transform: A closure that combines the previously reduced result and
   ///     the next element in the receiving asynchronous sequence and returns
   ///     the result. If the closure throws an error, the sequence throws.
-  /// - Returns: An asynchronous sequence of the initial value followed by the reduced
-  ///   elements.
+  /// - Returns: An asynchronous sequence of the reduced elements.
   @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func reductions<Result>(
@@ -38,8 +41,12 @@ extension AsyncSequence {
   /// Returns an asynchronous sequence containing the accumulated results of combining the
   /// elements of the asynchronous sequence using the given error-throwing closure.
   ///
-  /// This can be seen as applying the reduce function to each element and
-  /// providing the initial value followed by these results as an asynchronous sequence.
+  /// Starting from the initial value, this combines each element of the base
+  /// asynchronous sequence with the running result and emits each intermediate
+  /// result. The initial value itself is not emitted, so the first element of
+  /// the returned sequence is the result of combining the initial value with
+  /// the first element of the base sequence. If the base sequence is empty, the
+  /// returned sequence is also empty.
   ///
   /// - Parameters:
   ///   - initial: The value to use as the initial value.
@@ -47,8 +54,7 @@ extension AsyncSequence {
   ///     the next element in the receiving asynchronous sequence, mutating the
   ///     previous result instead of returning a value. If the closure throws an
   ///     error, the sequence throws.
-  /// - Returns: An asynchronous sequence of the initial value followed by the reduced
-  ///   elements.
+  /// - Returns: An asynchronous sequence of the reduced elements.
   @available(AsyncAlgorithms 1.0, *)
   @inlinable
   public func reductions<Result>(

--- a/Tests/AsyncAlgorithmsTests/TestReductions.swift
+++ b/Tests/AsyncAlgorithmsTests/TestReductions.swift
@@ -27,6 +27,34 @@ final class TestReductions: XCTestCase {
     XCTAssertNil(pastEnd)
   }
 
+  func test_reductions_empty() async {
+    let sequence = [Int]().async.reductions("") { partial, value in
+      partial + "\(value)"
+    }
+    var iterator = sequence.makeAsyncIterator()
+    var collected = [String]()
+    while let item = await iterator.next() {
+      collected.append(item)
+    }
+    XCTAssertEqual(collected, [])
+    let pastEnd = await iterator.next()
+    XCTAssertNil(pastEnd)
+  }
+
+  func test_throwing_reductions_empty() async throws {
+    let sequence = [Int]().async.reductions("") { (partial, value) throws -> String in
+      partial + "\(value)"
+    }
+    var iterator = sequence.makeAsyncIterator()
+    var collected = [String]()
+    while let item = try await iterator.next() {
+      collected.append(item)
+    }
+    XCTAssertEqual(collected, [])
+    let pastEnd = try await iterator.next()
+    XCTAssertNil(pastEnd)
+  }
+
   func test_inclusive_reductions() async {
     let sequence = [1, 2, 3, 4].async.reductions { $0 + $1 }
     var iterator = sequence.makeAsyncIterator()


### PR DESCRIPTION
The documentation for the exclusive `reductions` overloads says the returned sequence is "the initial value followed by the reduced elements", but that is not what happens. `AsyncExclusiveReductionsSequence.Iterator.next()` pulls a base element before emitting anything, so the first emitted element is the result of combining the initial value with the first base element, and the initial value itself is never emitted. For an empty base sequence the result is empty rather than a single element containing the initial value.

This is the behavior the existing tests already encode (for example `[1, 2, 3, 4].async.reductions("") { ... }` is expected to produce `["1", "12", "123", "1234"]`, not `["", "1", "12", "123", "1234"]`), and changing it would be source-breaking. This corrects the documentation to match the implementation instead, as suggested in the issue.

Changes:

- Rewrite the description and `Returns` line for all four exclusive overloads (throwing and non-throwing, the value-returning and `into:` forms) to state that each emitted element is an accumulated result starting from the initial value, that the initial value is not emitted, and that an empty base produces an empty sequence.
- Add `test_reductions_empty` and `test_throwing_reductions_empty` covering the empty-base case, which was previously untested and is the most surprising consequence of the corrected wording.

The inclusive reductions doc comments and the DocC Reductions guide already describe the actual behavior, so they are left unchanged.

Testing: `swift build` and `swift test` both pass locally (358 tests, including the two new cases). `swift format lint --strict` is clean on the changed files.

Resolves #386.
