### PR TITLE
Make MultiProducerSingleConsumerAsyncChannel internals compatible with library evolution

### DIFF
--- a/Sources/AsyncAlgorithms/Internal/_TinyArray.swift
+++ b/Sources/AsyncAlgorithms/Internal/_TinyArray.swift
@@ -26,8 +26,10 @@
 /// It supports arbitrary many elements but if only up to one ``Element`` is stored it does **not** allocate separate storage on the heap
 /// and instead stores the ``Element`` inline.
 @usableFromInline
+@frozen
 struct _TinyArray<Element> {
   @usableFromInline
+  @frozen
   enum Storage {
     case one(Element)
     case arbitrary([Element])

--- a/Sources/AsyncAlgorithms/MultiProducerSingleConsumerChannel/MultiProducerSingleConsumerAsyncChannel+Internal.swift
+++ b/Sources/AsyncAlgorithms/MultiProducerSingleConsumerChannel/MultiProducerSingleConsumerAsyncChannel+Internal.swift
@@ -16,8 +16,10 @@ import Synchronization
 @available(AsyncAlgorithms 1.1, *)
 extension MultiProducerSingleConsumerAsyncChannel {
   @usableFromInline
+  @frozen
   enum _InternalBackpressureStrategy: Sendable, CustomStringConvertible {
     @usableFromInline
+    @frozen
     struct _Watermark: Sendable, CustomStringConvertible {
       /// The low watermark where demand should start.
       @usableFromInline
@@ -118,7 +120,7 @@ extension MultiProducerSingleConsumerAsyncChannel {
     @usableFromInline
     let _stateMachine: Mutex<_StateMachine>
 
-    @inlinable
+    @usableFromInline
     init(
       backpressureStrategy: _InternalBackpressureStrategy
     ) {
@@ -505,6 +507,7 @@ extension MultiProducerSingleConsumerAsyncChannel {
 extension MultiProducerSingleConsumerAsyncChannel._Storage {
   /// The state machine of the channel.
   @usableFromInline
+  @frozen
   struct _StateMachine: ~Copyable {
     /// The state machine's current state.
     @usableFromInline
@@ -1358,6 +1361,7 @@ extension MultiProducerSingleConsumerAsyncChannel._Storage {
       ///   destructively pattern-matching an enum case with multiple payloads
       ///   that include a `~Copyable` generic wrapper type (`Disconnected`).
       @usableFromInline
+      @frozen
       struct ResumeElement: ~Copyable, Sendable {
         @usableFromInline let continuation: UnsafeContinuation<Element?, Error>
         @usableFromInline var element: Disconnected<Element>
@@ -1375,6 +1379,7 @@ extension MultiProducerSingleConsumerAsyncChannel._Storage {
       ///
       /// - Note: See `ResumeElement` for the reason behind this wrapper.
       @usableFromInline
+      @frozen
       struct ResumeElementAndProducers: ~Copyable, Sendable {
         @usableFromInline let continuation: UnsafeContinuation<Element?, Error>
         @usableFromInline var element: Disconnected<Element>
@@ -1395,6 +1400,7 @@ extension MultiProducerSingleConsumerAsyncChannel._Storage {
       ///
       /// - Note: See `ResumeElement` for the reason behind this wrapper.
       @usableFromInline
+      @frozen
       struct ResumeFailure: ~Copyable, Sendable {
         @usableFromInline let continuation: UnsafeContinuation<Element?, Error>
         @usableFromInline let failure: Failure?
@@ -1560,8 +1566,10 @@ extension MultiProducerSingleConsumerAsyncChannel._Storage {
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension MultiProducerSingleConsumerAsyncChannel._Storage._StateMachine {
   @usableFromInline
+  @frozen
   enum _State: ~Copyable {
     @usableFromInline
+    @frozen
     struct Channeling: ~Copyable {
       /// The backpressure strategy.
       @usableFromInline
@@ -1662,6 +1670,7 @@ extension MultiProducerSingleConsumerAsyncChannel._Storage._StateMachine {
     }
 
     @usableFromInline
+    @frozen
     struct SourceFinished: ~Copyable {
       /// Indicates if the iterator was initialized.
       @usableFromInline
@@ -1718,6 +1727,7 @@ extension MultiProducerSingleConsumerAsyncChannel._Storage._StateMachine {
     }
 
     @usableFromInline
+    @frozen
     struct Finished: ~Copyable {
       /// Indicates if the iterator was initialized.
       @usableFromInline
@@ -1783,6 +1793,7 @@ enum _MultiProducerSingleConsumerSuspendedProducer: @unchecked Sendable {
 
 // TODO: This should be replaced with Disconnected once we have a UniqueDeque
 @usableFromInline
+@frozen
 struct SendableConsumeOnceBox<Wrapped> {
   @usableFromInline
   var wrapped: Optional<Wrapped>


### PR DESCRIPTION
`MultiProducerSingleConsumerAsyncChannel`, introduced in 1.1.0, fails to compile when the consuming module is built with library evolution enabled (`BUILD_LIBRARY_FOR_DISTRIBUTION=YES`, i.e. `-enable-library-evolution`). This blocks every team that distributes a binary SDK as an XCFramework depending on `swift-async-algorithms`; the 1.0.x line is currently the only usable version for them.

Two classes of error come from `Sources/AsyncAlgorithms/MultiProducerSingleConsumerChannel/MultiProducerSingleConsumerAsyncChannel+Internal.swift`:

- `'consume' can only be used to partially consume storage` — the `@inlinable mutating func` methods on the non-`@frozen` `_StateMachine` struct (and the `_InternalBackpressureStrategy` enum) do `switch consume self._state` / `switch consume self`. Under library evolution a non-frozen type's stored properties are reached through resilient accessors, which do not vend the direct ownership `consume` requires.
- `initializer for class '_Storage' is '@inlinable' and must delegate to another initializer`, plus the related `'let' property ... may not be initialized directly` errors on the `@inlinable` initializers of the `~Copyable` payload structs. Under library evolution an `@inlinable` initializer of a resilient type may only assign through a delegating `self.init`/`self = ...`, not set stored properties directly.

These reproduce on 1.1.0–1.1.3; `main` is still affected.

Changes:

- Mark the internal (`@usableFromInline`) types whose stored storage is `consume`d or directly initialized in `@inlinable` members as `@frozen`, so their layout is fixed and direct storage access / `consume` is permitted under library evolution: `_StateMachine`, `_State` and its `Channeling`/`SourceFinished`/`Finished` payloads, `_InternalBackpressureStrategy` and its `_Watermark`, the `ResumeElement`/`ResumeElementAndProducers`/`ResumeFailure` wrappers, and `SendableConsumeOnceBox`. These are all already `@usableFromInline` internal types, so freezing them is not a public-API or source-stability change.
- Mark `_TinyArray` and its `Storage` enum `@frozen` for the same reason (they back the frozen payloads).
- Change `_Storage.init(backpressureStrategy:)` from `@inlinable` to `@usableFromInline`, since an `@inlinable` designated class initializer must delegate under library evolution and this one sets a stored property directly.

No public API changes and no behavioral changes — only resilience-attribute additions on internal types and one inlinability downgrade on an internal initializer.

Testing:

- `swift build --target AsyncAlgorithms -Xswiftc -enable-library-evolution` now succeeds (it fails on `main` with the errors above).
- `swift build` (normal, non-evolution) succeeds.
- `swift test --filter MultiProducerSingleConsumer` passes — 37 tests, 0 failures.

Fixes #405.
