### PR TITLE
[AsyncStreaming] Exclude the proposal file from the target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -70,6 +70,7 @@ let package = Package(
         .product(name: "ContainersPreview", package: "swift-collections"),
         .product(name: "DequeModule", package: "swift-collections"),
       ],
+      exclude: ["NNNN-async-streaming.md"],
       swiftSettings: [
         .enableExperimentalFeature("SuppressedAssociatedTypesWithDefaults"),
         .enableExperimentalFeature("LifetimeDependence"),


### PR DESCRIPTION
## Motivation

The generalized async streaming proposal, `NNNN-async-streaming.md`, lives in `Sources/AsyncStreaming/` alongside the implementation. Because it is a Markdown document rather than a build input, SwiftPM reports it as an unhandled file on every build (#433):

    warning: 'swift-async-algorithms': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
        Sources/AsyncStreaming/NNNN-async-streaming.md

## Modifications

The proposal is intentionally kept next to the implementation, so it is excluded from the `AsyncStreaming` target in `Package.swift` rather than being moved:

    exclude: ["NNNN-async-streaming.md"]

## Result

`swift build` no longer emits the unhandled-file warning, and the proposal stays alongside the implementation.

Resolves #433.