### PR TITLE
[Merge] Add isolated next for AsyncMerge2Sequence

### DIFF
--- a/Sources/AsyncAlgorithms/Merge/AsyncMerge2Sequence.swift
+++ b/Sources/AsyncAlgorithms/Merge/AsyncMerge2Sequence.swift
@@ -102,6 +102,10 @@ extension AsyncMerge2Sequence {
     public mutating func next() async rethrows -> Element? {
       try await internalClass.next()
     }
+
+    public mutating func next(isolation actor: isolated (any Actor)? = #isolation) async rethrows -> Element? {
+      try await internalClass.next()
+    }
   }
 }
 

--- a/Tests/AsyncAlgorithmsTests/TestMerge.swift
+++ b/Tests/AsyncAlgorithmsTests/TestMerge.swift
@@ -170,6 +170,30 @@ final class TestMerge2: XCTestCase {
     XCTAssertEqual(collected.intersection(expected), expected)
   }
 
+  func test_merge_propagates_failure_when_first_is_throwing_and_second_is_non_throwing() async {
+    let first = [1].async.map { try throwOn(1, $0) }
+    let second = [2].async
+
+    do {
+      for try await _ in merge(first, second) {}
+      XCTFail("Merged sequence should throw when the first sequence throws")
+    } catch {
+      XCTAssertEqual(Failure(), error as? Failure)
+    }
+  }
+
+  func test_merge_propagates_failure_when_first_is_non_throwing_and_second_is_throwing() async {
+    let first = [1].async
+    let second = [2].async.map { try throwOn(2, $0) }
+
+    do {
+      for try await _ in merge(first, second) {}
+      XCTFail("Merged sequence should throw when the second sequence throws")
+    } catch {
+      XCTAssertEqual(Failure(), error as? Failure)
+    }
+  }
+
   #if canImport(Darwin) || canImport(Glibc) || canImport(Musl) || canImport(Bionic) || canImport(wasi_pthread)
   func test_merge_makes_sequence_with_ordered_elements_when_sources_follow_a_timeline() {
     validate {


### PR DESCRIPTION
## Summary
- Add an explicit `next(isolation:)` implementation to `AsyncMerge2Sequence.Iterator` so Swift 6 iteration does not fall back to the standard-library compatibility bridge.
- Add regression coverage for mixed throwing/non-throwing `merge` inputs in both argument orders.

## Motivation
With Swift 6 typed `AsyncSequence.Failure`, `for await` can call `next(isolation:)`. Without an explicit implementation, `AsyncMerge2Sequence.Iterator` can use the default bridge through legacy `next()`, which force-casts thrown errors to the inferred `Failure` type. For mixed throwing and non-throwing inputs, that can trap when a later input throws while the merged sequence is inferred as non-throwing.

This is related to #391.

## Test plan
- `swift test --filter TestMerge2`
- `swift test --filter TestMerge`
- `swift test`