### PR TITLE
[Merge] Add isolated next for AsyncMerge2Sequence

### DIFF
--- a/Sources/AsyncAlgorithms/Merge/AsyncMerge2Sequence.swift
+++ b/Sources/AsyncAlgorithms/Merge/AsyncMerge2Sequence.swift
@@ -102,6 +102,10 @@ extension AsyncMerge2Sequence {
     public mutating func next() async rethrows -> Element? {
       try await internalClass.next()
     }
+
+    public mutating func next(isolation actor: isolated (any Actor)? = #isolation) async rethrows -> Element? {
+      try await internalClass.next()
+    }
   }
 }
 

--- a/Tests/AsyncAlgorithmsTests/TestMerge.swift
+++ b/Tests/AsyncAlgorithmsTests/TestMerge.swift
@@ -216,6 +216,37 @@ final class TestMerge2: XCTestCase {
   }
 }
 
+#if compiler(>=6.0)
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+final class TestMerge2Isolation: XCTestCase {
+  func test_merge_propagates_failure_when_first_is_throwing_and_second_is_non_throwing() async {
+    let first = [1].async.map { try throwOn(1, $0) }
+    let second = [2].async
+    var iterator = merge(first, second).makeAsyncIterator()
+
+    do {
+      while let _ = try await iterator.next(isolation: nil) {}
+      XCTFail("Merged sequence should throw when the first sequence throws")
+    } catch {
+      XCTAssertEqual(Failure(), error as? Failure)
+    }
+  }
+
+  func test_merge_propagates_failure_when_first_is_non_throwing_and_second_is_throwing() async {
+    let first = [1].async
+    let second = [2].async.map { try throwOn(2, $0) }
+    var iterator = merge(first, second).makeAsyncIterator()
+
+    do {
+      while let _ = try await iterator.next(isolation: nil) {}
+      XCTFail("Merged sequence should throw when the second sequence throws")
+    } catch {
+      XCTAssertEqual(Failure(), error as? Failure)
+    }
+  }
+}
+#endif
+
 final class TestMerge3: XCTestCase {
   func test_merge_makes_sequence_with_elements_from_sources_when_all_have_same_size() async {
     let first = [1, 2, 3]


### PR DESCRIPTION
## Summary
- Add an explicit `next(isolation:)` implementation to `AsyncMerge2Sequence.Iterator`.
- Add Swift 6 availability-gated regression tests for mixed throwing and non-throwing merge inputs in both argument orders.

## Motivation
Swift 6 async iteration can call `next(isolation:)`. Without an explicit implementation, `AsyncMerge2Sequence.Iterator` can fall back to the standard-library compatibility bridge through legacy `next()`. For mixed throwing and non-throwing inputs, that bridge can force-cast an upstream error to `Never` and trap.

This is related to #391.

## Test plan
- `swift test --filter TestMerge2Isolation`
- Temporarily removing `next(isolation:)` reproduces the `Failure` to `Never` cast crash in `TestMerge2Isolation`.
- `swift test`